### PR TITLE
WIP: Add preact-testing-library documentation to testing-library.com/preact

### DIFF
--- a/docs/preact-testing-library/api.md
+++ b/docs/preact-testing-library/api.md
@@ -1,0 +1,273 @@
+---
+id: api
+title: API
+---
+
+`react-testing-library` re-exports everything from `dom-testing-library` as well
+as these methods:
+
+- [`render`](#act)
+- [`cleanup`](#cleanup)
+- [`act`](#act)
+
+---
+
+## `render`
+
+```typescript
+function render(
+  ui: React.ReactElement<any>,
+  options?: {
+    /* You won't often use this, expand below for docs on options */
+  }
+): RenderResult
+```
+
+Render into a container which is appended to `document.body`.
+
+```jsx
+import { render } from 'react-testing-library'
+
+render(<div />)
+```
+
+```jsx
+import { render, cleanup } from 'react-testing-library'
+import 'jest-dom/extend-expect'
+afterEach(cleanup)
+
+test('renders a message', () => {
+  const { container, getByText } = render(<Greeting />)
+  expect(getByText('Hello, world!')).toBeInTheDocument()
+  expect(container.firstChild).toMatchInlineSnapshot(`
+    <h1>Hello, World!</h1>
+  `)
+})
+```
+
+> Note
+>
+> The [cleanup](#cleanup) function should be called between tests to remove the
+> created DOM nodes and keep the tests isolated.
+
+## `render` Options
+
+You wont often need to specify options, but if you ever do, here are the
+available options which you could provide as a second argument to `render`.
+
+### `container`
+
+By default, `react-testing-library` will create a `div` and append that div to
+the `document.body` and this is where your react component will be rendered. If
+you provide your own HTMLElement `container` via this option, it will not be
+appended to the `document.body` automatically.
+
+For Example: If you are unit testing a `tablebody` element, it cannot be a child
+of a `div`. In this case, you can specify a `table` as the render `container`.
+
+```jsx
+const table = document.createElement('table')
+
+const { container } = render(<TableBody {...props} />, {
+  container: document.body.appendChild(table),
+})
+```
+
+### `baseElement`
+
+If the `container` is specified, then this defaults to that, otherwise this
+defaults to `document.documentElement`. This is used as the base element for the
+queries as well as what is printed when you use `debug()`.
+
+### `hydrate`
+
+If hydrate is set to true, then it will render with
+[ReactDOM.hydrate](https://reactjs.org/docs/react-dom.html#hydrate). This may be
+useful if you are using server-side rendering and use ReactDOM.hydrate to mount
+your components.
+
+### `wrapper`
+
+Pass a React Component as the `wrapper` option to have it rendered around the
+inner element. This is most useful for creating reusable custom render functions
+for common data providers. See [setup](setup.md#custom-render) for examples.
+
+## `render` Result
+
+The `render` method returns an object that has a few properties:
+
+### `...queries`
+
+The most important feature of `render` is that the queries from
+[dom-testing-library](api-queries.md) are automatically returned with their
+first argument bound to the [baseElement](#baseelement), which defaults to
+`document.body`.
+
+See [Queries](api-queries.md) for a complete list.
+
+**Example**
+
+```jsx
+const { getByLabelText, queryAllByTestId } = render(<Component />)
+```
+
+### `container`
+
+The containing DOM node of your rendered React Element (rendered using
+`ReactDOM.render`). It's a `div`. This is a regular DOM node, so you can call
+`container.querySelector` etc. to inspect the children.
+
+> Tip: To get the root element of your rendered element, use
+> `container.firstChild`.
+>
+> NOTE: When that root element is a
+> [React Fragment](https://reactjs.org/docs/fragments.html),
+> `container.firstChild` will only get the first child of that Fragment, not the
+> Fragment itself.
+
+> 🚨 If you find yourself using `container` to query for rendered elements then
+> you should reconsider! The other queries are designed to be more resiliant to
+> changes that will be made to the component you're testing. Avoid using
+> `container` to query for elements!
+
+### `baseElement`
+
+The containing DOM node where your React Element is rendered in the container.
+If you don't specify the `baseElement` in the options of `render`, it will
+default to `document.body`.
+
+This is useful when the component you want to test renders something outside the
+container div, e.g. when you want to snapshot test your portal component which
+renders it's HTML directly in the body.
+
+> Note: the queries returned by the `render` looks into baseElement, so you can
+> use queries to test your portal component without the baseElement.
+
+### `debug`
+
+This method is a shortcut for `console.log(prettyDOM(baseElement))`.
+
+```jsx
+import React from 'react'
+import { render } from 'react-testing-library'
+
+const HelloWorld = () => <h1>Hello World</h1>
+const { debug } = render(<HelloWorld />)
+debug()
+// <div>
+//   <h1>Hello World</h1>
+// </div>
+// you can also pass an element: debug(getByTestId('messages'))
+```
+
+This is a simple wrapper around `prettyDOM` which is also exposed and comes from
+[`dom-testing-library`](https://github.com/kentcdodds/dom-testing-library/blob/master/README.md#prettydom).
+
+### `rerender`
+
+It'd probably be better if you test the component that's doing the prop updating
+to ensure that the props are being updated correctly (see
+[the Guiding Principles section](#guiding-principles)). That said, if you'd
+prefer to update the props of a rendered component in your test, this function
+can be used to update props of the rendered component.
+
+```jsx
+import { render } from 'react-testing-library'
+
+const { rerender } = render(<NumberDisplay number={1} />)
+
+// re-render the same component with different props
+rerender(<NumberDisplay number={2} />)
+```
+
+[See the examples page](example-update-props.md)
+
+### `unmount`
+
+This will cause the rendered component to be unmounted. This is useful for
+testing what happens when your component is removed from the page (like testing
+that you don't leave event handlers hanging around causing memory leaks).
+
+> This method is a pretty small abstraction over
+> `ReactDOM.unmountComponentAtNode`
+
+```jsx
+import { render } from 'react-testing-library'
+
+const { container, unmount } = render(<Login />)
+unmount()
+// your component has been unmounted and now: container.innerHTML === ''
+```
+
+### `asFragment`
+
+Returns a `DocumentFragment` of your rendered component. This can be useful if
+you need to avoid live bindings and see how your component reacts to events.
+
+```jsx
+import { render, fireEvent } from 'react-testing-library'
+
+class TestComponent extends React.Component {
+  constructor() {
+    super()
+    this.state = { count: 0 }
+  }
+
+  render() {
+    const { count } = this.state
+
+    return (
+      <button onClick={() => this.setState({ count: count + 1 })}>
+        Click to increase: {count}
+      </button>
+    )
+  }
+}
+
+const { getByText, asFragment } = render(<TestComponent />)
+const firstRender = asFragment()
+
+fireEvent.click(getByText(/Click to increase/))
+
+// This will snapshot only the difference between the first render, and the
+// state of the DOM after the click event.
+// See https://github.com/jest-community/snapshot-diff
+expect(firstRender).toMatchDiffSnapshot(asFragment())
+```
+
+---
+
+## `cleanup`
+
+Unmounts React trees that were mounted with [render](#render).
+
+```jsx
+import { cleanup, render } from 'react-testing-library'
+
+afterEach(cleanup) // <-- add this
+
+test('renders into document', () => {
+  render(<div />)
+  // ...
+})
+
+// ... more tests ...
+```
+
+Failing to call `cleanup` when you've called `render` could result in a memory
+leak and tests which are not "idempotent" (which can lead to difficult to debug
+errors in your tests).
+
+**If you don't want to add this to _every single test file_** then we recommend
+that you configure your test framework to run a file before your tests which
+does this automatically. See the [setup](./setup) section for guidance on how to
+set up your framework.
+
+---
+
+## `act`
+
+This is a light wrapper around the
+[`react-dom/test-utils` `act` function](https://reactjs.org/docs/test-utils.html#act).
+All it does is forward all arguments to the act function if your version of
+react supports `act`.

--- a/docs/preact-testing-library/api.md
+++ b/docs/preact-testing-library/api.md
@@ -3,8 +3,8 @@ id: api
 title: API
 ---
 
-`react-testing-library` re-exports everything from `dom-testing-library` as well
-as these methods:
+`preact-testing-library` re-exports everything from `dom-testing-library` as
+well as these methods:
 
 - [`render`](#act)
 - [`cleanup`](#cleanup)
@@ -26,13 +26,13 @@ function render(
 Render into a container which is appended to `document.body`.
 
 ```jsx
-import { render } from 'react-testing-library'
+import { render } from 'preact-testing-library'
 
 render(<div />)
 ```
 
 ```jsx
-import { render, cleanup } from 'react-testing-library'
+import { render, cleanup } from 'preact-testing-library'
 import 'jest-dom/extend-expect'
 afterEach(cleanup)
 
@@ -57,7 +57,7 @@ available options which you could provide as a second argument to `render`.
 
 ### `container`
 
-By default, `react-testing-library` will create a `div` and append that div to
+By default, `preact-testing-library` will create a `div` and append that div to
 the `document.body` and this is where your react component will be rendered. If
 you provide your own HTMLElement `container` via this option, it will not be
 appended to the `document.body` automatically.
@@ -149,7 +149,7 @@ This method is a shortcut for `console.log(prettyDOM(baseElement))`.
 
 ```jsx
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render } from 'preact-testing-library'
 
 const HelloWorld = () => <h1>Hello World</h1>
 const { debug } = render(<HelloWorld />)
@@ -172,7 +172,7 @@ prefer to update the props of a rendered component in your test, this function
 can be used to update props of the rendered component.
 
 ```jsx
-import { render } from 'react-testing-library'
+import { render } from 'preact-testing-library'
 
 const { rerender } = render(<NumberDisplay number={1} />)
 
@@ -192,7 +192,7 @@ that you don't leave event handlers hanging around causing memory leaks).
 > `ReactDOM.unmountComponentAtNode`
 
 ```jsx
-import { render } from 'react-testing-library'
+import { render } from 'preact-testing-library'
 
 const { container, unmount } = render(<Login />)
 unmount()
@@ -205,7 +205,7 @@ Returns a `DocumentFragment` of your rendered component. This can be useful if
 you need to avoid live bindings and see how your component reacts to events.
 
 ```jsx
-import { render, fireEvent } from 'react-testing-library'
+import { render, fireEvent } from 'preact-testing-library'
 
 class TestComponent extends React.Component {
   constructor() {
@@ -242,7 +242,7 @@ expect(firstRender).toMatchDiffSnapshot(asFragment())
 Unmounts React trees that were mounted with [render](#render).
 
 ```jsx
-import { cleanup, render } from 'react-testing-library'
+import { cleanup, render } from 'preact-testing-library'
 
 afterEach(cleanup) // <-- add this
 

--- a/docs/preact-testing-library/example-intro.md
+++ b/docs/preact-testing-library/example-intro.md
@@ -1,0 +1,133 @@
+---
+id: example-intro
+title: Example
+sidebar_label: Example
+---
+
+## Full Example
+
+See the following sections for a detailed breakdown of the test
+
+```jsx
+// __tests__/fetch.test.js
+import React from 'react'
+import {
+  render,
+  fireEvent,
+  cleanup,
+  waitForElement,
+} from 'react-testing-library'
+import 'jest-dom/extend-expect'
+import axiosMock from 'axios'
+import Fetch from '../fetch'
+
+afterEach(cleanup)
+
+test('loads and displays greeting', async () => {
+  const url = '/greeting'
+  const { getByText, getByTestId } = render(<Fetch url={url} />)
+
+  axiosMock.get.mockResolvedValueOnce({
+    data: { greeting: 'hello there' },
+  })
+
+  fireEvent.click(getByText('Load Greeting'))
+
+  const greetingTextNode = await waitForElement(() =>
+    getByTestId('greeting-text')
+  )
+
+  expect(axiosMock.get).toHaveBeenCalledTimes(1)
+  expect(axiosMock.get).toHaveBeenCalledWith(url)
+  expect(getByTestId('greeting-text')).toHaveTextContent('hello there')
+  expect(getByTestId('ok-button')).toHaveAttribute('disabled')
+})
+```
+
+## Imports
+
+```jsx
+// import dependencies
+import React from 'react'
+
+// import react-testing methods
+import {
+  render,
+  fireEvent,
+  cleanup,
+  waitForElement,
+} from 'react-testing-library'
+
+// add custom jest matchers from jest-dom
+import 'jest-dom/extend-expect'
+
+// the axios mock is in __mocks__/
+// see https://jestjs.io/docs/en/manual-mocks
+import axiosMock from 'axios'
+
+// the component to test
+import Fetch from '../fetch'
+```
+
+## Test
+
+```jsx
+// automatically unmount and cleanup DOM after the test is finished.
+afterEach(cleanup)
+
+test('loads and displays greeting', async () => {
+  // Arrange
+  // Act
+  // Assert
+})
+```
+
+### Arrange
+
+The [`render`](./ecosystem-react-testing-library#render) method renders a React
+element into the DOM and returns utility functions for testing the component.
+
+```jsx
+const url = '/greeting'
+const { getByText, getByTestId, container, asFragment } = render(
+  <Fetch url={url} />
+)
+```
+
+### Act
+
+The [`fireEvent`](./api-events#fireEvent) method allows you to fire events to
+simulate user actions.
+
+```jsx
+axiosMock.get.mockResolvedValueOnce({
+  data: { greeting: 'hello there' },
+})
+
+fireEvent.click(getByText('Load Greeting'))
+
+// Wait until the mocked `get` request promise resolves and
+// the component calls setState and re-renders.
+// `waitForElement` waits until the callback doesn't throw an error
+
+const greetingTextNode = await waitForElement(() =>
+  // getByTestId throws an error if it cannot find an element
+  getByTestId('greeting-text')
+)
+```
+
+### Assert
+
+```jsx
+expect(axiosMock.get).toHaveBeenCalledTimes(1)
+expect(axiosMock.get).toHaveBeenCalledWith(url)
+expect(getByTestId('greeting-text')).toHaveTextContent('hello there')
+expect(getByTestId('ok-button')).toHaveAttribute('disabled')
+
+// snapshots work great with regular DOM nodes!
+expect(container.firstChild).toMatchSnapshot()
+
+// you can also use get a `DocumentFragment`,
+// which is useful if you want to compare nodes across render
+expect(asFragment()).toMatchSnapshot()
+```

--- a/docs/preact-testing-library/faq.md
+++ b/docs/preact-testing-library/faq.md
@@ -1,0 +1,220 @@
+---
+id: faq
+title: FAQ
+---
+
+See also the [main FAQ](/docs/faq) for questions not specific to React testing
+
+<details>
+
+<summary>How do I test input onChange handlers?</summary>
+
+TL;DR:
+[Go to the `on-change.js` example](https://codesandbox.io/s/github/kentcdodds/react-testing-library-examples/tree/master/?module=%2Fsrc%2F__tests__%2Fon-change.js&previewwindow=tests)
+
+In summary:
+
+```javascript
+import React from 'react'
+import 'react-testing-library/cleanup-after-each'
+import { render, fireEvent } from 'react-testing-library'
+
+test('change values via the fireEvent.change method', () => {
+  const handleChange = jest.fn()
+  const { container } = render(<input type="text" onChange={handleChange} />)
+  const input = container.firstChild
+  fireEvent.change(input, { target: { value: 'a' } })
+  expect(handleChange).toHaveBeenCalledTimes(1)
+  expect(input.value).toBe('a')
+})
+
+test('checkboxes (and radios) must use fireEvent.click', () => {
+  const handleChange = jest.fn()
+  const { container } = render(
+    <input type="checkbox" onChange={handleChange} />
+  )
+  const checkbox = container.firstChild
+  fireEvent.click(checkbox)
+  expect(handleChange).toHaveBeenCalledTimes(1)
+  expect(checkbox.checked).toBe(true)
+})
+```
+
+If you've used enzyme or React's TestUtils, you may be accustomed to changing
+inputs like so:
+
+```javascript
+input.value = 'a'
+Simulate.change(input)
+```
+
+We can't do this with react-testing-library because React actually keeps track
+of any time you assign the `value` property on an `input` and so when you fire
+the `change` event, React thinks that the value hasn't actually been changed.
+
+This works for Simulate because they use internal APIs to fire special simulated
+events. With react-testing-library, we try to avoid implementation details to
+make your tests more resiliant.
+
+So we have it worked out for the change event handler to set the property for
+you in a way that's not trackable by React. This is why you must pass the value
+as part of the `change` method call.
+
+</details>
+
+<details>
+
+<summary>Can I write unit tests with this library?</summary>
+
+Definitely yes! You can write unit and integration tests with this library. See
+below for more on how to mock dependencies (because this library intentionally
+does NOT support shallow rendering) if you want to unit test a high level
+component. The tests in this project show several examples of unit testing with
+this library.
+
+As you write your tests, keep in mind:
+
+> The more your tests resemble the way your software is used, the more
+> confidence they can give you. - [17 Feb 2018][guiding-principle]
+
+</details>
+
+<details>
+
+<summary>If I can't use shallow rendering, how do I mock out components in tests?</summary>
+
+In general, you should avoid mocking out components (see
+[the Guiding Principles section](./guiding-principles)). However if you need to,
+then it's pretty trivial using
+[Jest's mocking feature](https://facebook.github.io/jest/docs/en/manual-mocks.html).
+One case that I've found mocking to be especially useful is for animation
+libraries. I don't want my tests to wait for animations to end.
+
+```javascript
+jest.mock('react-transition-group', () => {
+  const FakeTransition = jest.fn(({ children }) => children)
+  const FakeCSSTransition = jest.fn(props =>
+    props.in ? <FakeTransition>{props.children}</FakeTransition> : null
+  )
+  return { CSSTransition: FakeCSSTransition, Transition: FakeTransition }
+})
+
+test('you can mock things with jest.mock', () => {
+  const { getByTestId, queryByTestId } = render(
+    <HiddenMessage initialShow={true} />
+  )
+  expect(queryByTestId('hidden-message')).toBeTruthy() // we just care it exists
+  // hide the message
+  fireEvent.click(getByTestId('toggle-message'))
+  // in the real world, the CSSTransition component would take some time
+  // before finishing the animation which would actually hide the message.
+  // So we've mocked it out for our tests to make it happen instantly
+  expect(queryByTestId('hidden-message')).toBeNull() // we just care it doesn't exist
+})
+```
+
+Note that because they're Jest mock functions (`jest.fn()`), you could also make
+assertions on those as well if you wanted.
+
+[Open full test](./example-react-transition-group) for the full example.
+
+This looks like more work that shallow rendering (and it is), but it gives you
+more confidence so long as your mock resembles the thing you're mocking closely
+enough.
+
+If you want to make things more like shallow rendering, then you could do
+something more [like this]([Open full test](./example-react-transition-group) ).
+
+Learn more about how Jest mocks work from my blog post:
+["But really, what is a JavaScript mock?"](https://blog.kentcdodds.com/but-really-what-is-a-javascript-mock-10d060966f7d)
+
+</details>
+
+<details>
+
+<summary>What about enzyme is "bloated with complexity and features" and "encourage
+poor testing practices"?</summary>
+
+Most of the damaging features have to do with encouraging testing implementation
+details. Primarily, these are
+[shallow rendering](http://airbnb.io/enzyme/docs/api/shallow.html), APIs which
+allow selecting rendered elements by component constructors, and APIs which
+allow you to get and interact with component instances (and their
+state/properties) (most of enzyme's wrapper APIs allow this).
+
+The guiding principle for this library is:
+
+> The more your tests resemble the way your software is used, the more
+> confidence they can give you. - [17 Feb 2018][guiding-principle]
+
+Because users can't directly interact with your app's component instances,
+assert on their internal state or what components they render, or call their
+internal methods, doing those things in your tests reduce the confidence they're
+able to give you.
+
+That's not to say that there's never a use case for doing those things, so they
+should be possible to accomplish, just not the default and natural way to test
+react components.
+
+</details>
+
+<details>
+
+<summary>Why isn't snapshot diffing working?</summary>
+
+If you use the [snapshot-diff](https://github.com/jest-community/snapshot-diff)
+library to save snapshot diffs, it won't work out of the box because this
+library uses the DOM which is mutable. Changes don't return new objects so
+snapshot-diff will think it's the same object and avoid diffing it.
+
+Luckily there's an easy way to make it work: clone the DOM when passing it into
+snapshot-diff. It looks like this:
+
+```js
+const firstVersion = container.cloneNode(true)
+// Do some changes
+snapshotDiff(firstVersion, container.cloneNode(true))
+```
+
+</details>
+
+<details>
+
+<summary>Does this library work with React Native?</summary>
+
+> This is still quite experimental - please contribute with your own
+> results/findings!
+
+The short answer is yes, but with a few caveats. It's possible to replicate a
+lot of DOM functionality with
+[`react-native-web`](https://github.com/necolas/react-native-web), allowing you
+to use the query APIs like `getByText`. You can then add a `press` event to
+`fireEvent` that simulates a mouseDown immediately followed by a mouseUp, and
+call this with Touchable\* components.
+
+One thing this approach does _not_ support is any kind of native module
+functionality (like native navigation modules). The way around this is to design
+your components so that as much of the functionality you need tested is
+encapsulated outside of any native module functionality.
+
+For a barebones example of testing a React Native component,
+[see here](https://github.com/thchia/rn-testing-library-example).
+
+There is also a sibling project called
+[react-native-testing-library](https://github.com/callstack/react-native-testing-library)
+which aims to test React Native apps without mentioned tradeoffs, having the API
+inspired by and mostly compatible with this library.
+
+</details>
+
+<!--
+Links:
+-->
+
+<!-- prettier-ignore-start -->
+
+[guiding-principle]: https://twitter.com/kentcdodds/status/977018512689455106
+[data-testid-blog-post]: https://blog.kentcdodds.com/making-your-ui-tests-resilient-to-change-d37a6ee37269
+[dom-testing-lib-textmatch]: https://github.com/kentcdodds/dom-testing-library#textmatch
+
+<!-- prettier-ignore-end -->

--- a/docs/preact-testing-library/faq.md
+++ b/docs/preact-testing-library/faq.md
@@ -16,8 +16,8 @@ In summary:
 
 ```javascript
 import React from 'react'
-import 'react-testing-library/cleanup-after-each'
-import { render, fireEvent } from 'react-testing-library'
+import 'preact-testing-library/cleanup-after-each'
+import { render, fireEvent } from 'preact-testing-library'
 
 test('change values via the fireEvent.change method', () => {
   const handleChange = jest.fn()
@@ -48,12 +48,12 @@ input.value = 'a'
 Simulate.change(input)
 ```
 
-We can't do this with react-testing-library because React actually keeps track
+We can't do this with preact-testing-library because React actually keeps track
 of any time you assign the `value` property on an `input` and so when you fire
 the `change` event, React thinks that the value hasn't actually been changed.
 
 This works for Simulate because they use internal APIs to fire special simulated
-events. With react-testing-library, we try to avoid implementation details to
+events. With preact-testing-library, we try to avoid implementation details to
 make your tests more resiliant.
 
 So we have it worked out for the change event handler to set the property for

--- a/docs/preact-testing-library/intro.md
+++ b/docs/preact-testing-library/intro.md
@@ -1,23 +1,23 @@
 ---
 id: intro
-title: React Testing Library
+title: Preact Testing Library
 sidebar_label: Introduction
 ---
 
 [`react-testing-library`][gh] builds on top of `dom-testing-library` by adding
-APIs for working with React components.
+APIs for working with Preact components.
 
 ```
-npm install --save-dev react-testing-library
+npm install --save-dev preact-testing-library
 ```
 
-- [react-testing-library on GitHub][gh]
+- [preact-testing-library on GitHub][gh]
 
-[gh]: https://github.com/kentcdodds/react-testing-library
+[gh]: https://github.com/antsmartian/preact-testing-library
 
 ## The problem
 
-You want to write maintainable tests for your React components. As a part of
+You want to write maintainable tests for your Preact components. As a part of
 this goal, you want your tests to avoid including implementation details of your
 components and rather focus on making your tests give you the confidence for
 which they are intended. As part of this, you want your testbase to be
@@ -27,14 +27,13 @@ your team down.
 
 ## This solution
 
-The `react-testing-library` is a very light-weight solution for testing React
-components. It provides light utility functions on top of `react-dom` and
-`react-dom/test-utils`, in a way that encourages better testing practices. Its
-primary guiding principle is:
+The `preact-testing-library` is a very light-weight solution for testing Preact
+components. It provides light utility functions on top of `preact` in a way that
+encourages better testing practices. It's primary guiding principle is:
 
 > [The more your tests resemble the way your software is used, the more confidence they can give you.](guiding-principles.md)
 
-So rather than dealing with instances of rendered react components, your tests
+So rather than dealing with instances of rendered preact components, your tests
 will work with actual DOM nodes. The utilities this library provides facilitate
 querying the DOM in the same way the user would. Finding for elements by their
 label text (just like a user would), finding links and buttons from their text
@@ -47,23 +46,20 @@ to get your tests closer to using your components the way a user will, which
 allows your tests to give you more confidence that your application will work
 when a real user uses it.
 
-This library is a replacement for [Enzyme](http://airbnb.io/enzyme/). While you
-_can_ follow these guidelines using Enzyme itself, enforcing this is harder
-because of all the extra utilities that Enzyme provides (utilities which
+This library is a replacement for [enzyme](http://airbnb.io/enzyme/). While you
+_can_ follow these guidelines using enzyme itself, enforcing this is harder
+because of all the extra utilities that enzyme provides (utilities which
 facilitate testing implementation details). Read more about this in
-[the FAQ](./faq).
+[the FAQ](#faq) below.
 
 **What this library is not**:
 
 1.  A test runner or framework
 2.  Specific to a testing framework (though we recommend Jest as our preference,
-    the library works with any framework. See
-    [Using Without Jest](./setup#using-without-jest))
+    the library works with any framework)
 
-> NOTE: This library is built on top of [`dom-testing-library`](/) which is
-> where most of the logic behind the queries is.
-
-## What is react-testing-library?
-
-Have a look at the video below for an explanation. <br/><br/>
-[![what is react testing library](https://img.youtube.com/vi/JKOwJUM4_RM/0.jpg)](https://youtu.be/JKOwJUM4_RM 'what is react testing library')
+> NOTE: This library is built on top of
+> [`dom-testing-library`](https://github.com/kentcdodds/dom-testing-library)
+> which is where most of the logic behind the queries is. Also this is inspired
+> from
+> [`react-testing-library`](https://github.com/kentcdodds/react-testing-library)

--- a/docs/preact-testing-library/intro.md
+++ b/docs/preact-testing-library/intro.md
@@ -1,0 +1,69 @@
+---
+id: intro
+title: React Testing Library
+sidebar_label: Introduction
+---
+
+[`react-testing-library`][gh] builds on top of `dom-testing-library` by adding
+APIs for working with React components.
+
+```
+npm install --save-dev react-testing-library
+```
+
+- [react-testing-library on GitHub][gh]
+
+[gh]: https://github.com/kentcdodds/react-testing-library
+
+## The problem
+
+You want to write maintainable tests for your React components. As a part of
+this goal, you want your tests to avoid including implementation details of your
+components and rather focus on making your tests give you the confidence for
+which they are intended. As part of this, you want your testbase to be
+maintainable in the long run so refactors of your components (changes to
+implementation but not functionality) don't break your tests and slow you and
+your team down.
+
+## This solution
+
+The `react-testing-library` is a very light-weight solution for testing React
+components. It provides light utility functions on top of `react-dom` and
+`react-dom/test-utils`, in a way that encourages better testing practices. Its
+primary guiding principle is:
+
+> [The more your tests resemble the way your software is used, the more confidence they can give you.](guiding-principles.md)
+
+So rather than dealing with instances of rendered react components, your tests
+will work with actual DOM nodes. The utilities this library provides facilitate
+querying the DOM in the same way the user would. Finding for elements by their
+label text (just like a user would), finding links and buttons from their text
+(like a user would). It also exposes a recommended way to find elements by a
+`data-testid` as an "escape hatch" for elements where the text content and label
+do not make sense or is not practical.
+
+This library encourages your applications to be more accessible and allows you
+to get your tests closer to using your components the way a user will, which
+allows your tests to give you more confidence that your application will work
+when a real user uses it.
+
+This library is a replacement for [Enzyme](http://airbnb.io/enzyme/). While you
+_can_ follow these guidelines using Enzyme itself, enforcing this is harder
+because of all the extra utilities that Enzyme provides (utilities which
+facilitate testing implementation details). Read more about this in
+[the FAQ](./faq).
+
+**What this library is not**:
+
+1.  A test runner or framework
+2.  Specific to a testing framework (though we recommend Jest as our preference,
+    the library works with any framework. See
+    [Using Without Jest](./setup#using-without-jest))
+
+> NOTE: This library is built on top of [`dom-testing-library`](/) which is
+> where most of the logic behind the queries is.
+
+## What is react-testing-library?
+
+Have a look at the video below for an explanation. <br/><br/>
+[![what is react testing library](https://img.youtube.com/vi/JKOwJUM4_RM/0.jpg)](https://youtu.be/JKOwJUM4_RM 'what is react testing library')

--- a/docs/preact-testing-library/setup.md
+++ b/docs/preact-testing-library/setup.md
@@ -4,11 +4,11 @@ title: Setup
 sidebar_label: Setup
 ---
 
-`react-testing-library` does not require any configuration to be used (as
+`preact-testing-library` does not require any configuration to be used (as
 demonstrated in the example above). However, there are some things you can do
 when configuring your testing framework to reduce some boilerplate. In these
 docs we'll demonstrate configuring Jest, but you should be able to do similar
-things with [any testing framework](#using-without-jest) (react-testing-library
+things with [any testing framework](#using-without-jest) (preact-testing-library
 does not require that you use Jest).
 
 ## Global Config
@@ -29,7 +29,7 @@ option to your Jest config:
 // jest.config.js
 module.exports = {
   setupFilesAfterEnv: [
-    'react-testing-library/cleanup-after-each',
+    'preact-testing-library/cleanup-after-each',
     // ... other setup files ...
   ],
   // ... other options ...
@@ -64,7 +64,7 @@ module.exports = {
 import 'jest-dom/extend-expect'
 
 // this is basically: afterEach(cleanup)
-import 'react-testing-library/cleanup-after-each'
+import 'preact-testing-library/cleanup-after-each'
 ```
 
 </details>
@@ -74,8 +74,8 @@ import 'react-testing-library/cleanup-after-each'
 It's often useful to define a custom render method that includes things like
 global context providers, data stores, etc. To make this available globally, one
 approach is to define a utility file that re-exports everything from
-`react-testing-library`. You can replace react-testing-library with this file in
-all your imports. See [below](#comfiguring-jest-with-test-utils) for a way to
+`preact-testing-library`. You can replace preact-testing-library with this file
+in all your imports. See [below](#comfiguring-jest-with-test-utils) for a way to
 make your test util file accessible without using relative paths.
 
 The example below sets up data providers using the
@@ -83,13 +83,13 @@ The example below sets up data providers using the
 
 ```diff
 // my-component.test.js
-- import { render, fireEvent } from 'react-testing-library';
+- import { render, fireEvent } from 'preact-testing-library';
 + import { render, fireEvent } from '../test-utils';
 ```
 
 ```js
 // test-utils.js
-import { render } from 'react-testing-library'
+import { render } from 'preact-testing-library'
 import { ThemeProvider } from 'my-ui-lib'
 import { TranslationProvider } from 'my-i18n-lib'
 import defaultStrings from 'i18n/en-x-default'
@@ -108,7 +108,7 @@ const customRender = (ui, options) =>
   render(ui, { wrapper: AllTheProviders, ...options })
 
 // re-export everything
-export * from 'react-testing-library'
+export * from 'preact-testing-library'
 
 // override render method
 export { customRender as render }
@@ -118,8 +118,8 @@ export { customRender as render }
 >
 > Babel versions lower than 7 throw an error when trying to override the named
 > export in the example above. See
-> [#169](https://github.com/kentcdodds/react-testing-library/issues/169) and the
-> workaround below.
+> [#169](https://github.com/kentcdodds/preact-testing-library/issues/169) and
+> the workaround below.
 
 <details>
 <summary>Workaround for Babel 6</summary>
@@ -128,7 +128,7 @@ You can use CommonJS modules instead of ES modules, which should work in Node:
 
 ```js
 // test-utils.js
-const rtl = require('react-testing-library')
+const rtl = require('preact-testing-library')
 
 const customRender = (ui, options) =>
   rtl.render(ui, {
@@ -200,8 +200,8 @@ NODE_PATH=src/utils
 ## Using without Jest
 
 If you're running your tests in the browser bundled with webpack (or similar)
-then `react-testing-library` should work out of the box for you. However, most
-people using react-testing-library are using it with the Jest testing framework
+then `preact-testing-library` should work out of the box for you. However, most
+people using preact-testing-library are using it with the Jest testing framework
 with the `testEnvironment` set to `jest-environment-jsdom` (which is the default
 configuration with Jest).
 

--- a/docs/preact-testing-library/setup.md
+++ b/docs/preact-testing-library/setup.md
@@ -1,0 +1,228 @@
+---
+id: setup
+title: Setup
+sidebar_label: Setup
+---
+
+`react-testing-library` does not require any configuration to be used (as
+demonstrated in the example above). However, there are some things you can do
+when configuring your testing framework to reduce some boilerplate. In these
+docs we'll demonstrate configuring Jest, but you should be able to do similar
+things with [any testing framework](#using-without-jest) (react-testing-library
+does not require that you use Jest).
+
+## Global Config
+
+Adding options to your global test config can simplify the setup and teardown of
+tests in individual files.
+
+### Cleanup
+
+You can ensure [`cleanup`](./api#cleanup) is called after each test and import
+additional assertions by adding it to the setup configuration in Jest.
+
+In Jest 24 and up, add the
+[`setupFilesAfterEnv`](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array)
+option to your Jest config:
+
+```javascript
+// jest.config.js
+module.exports = {
+  setupFilesAfterEnv: [
+    'react-testing-library/cleanup-after-each',
+    // ... other setup files ...
+  ],
+  // ... other options ...
+}
+```
+
+<details>
+
+<summary>Older versions of Jest</summary>
+
+Jest versions 23 and below use the
+[`setupTestFrameworkScriptFile`](https://jestjs.io/docs/en/23.x/configuration#setuptestframeworkscriptfile-string)
+option in your Jest config instead of `setupFilesAfterEnv`. This setup file can
+be anywhere, for example `jest.setup.js` or `./utils/setupTests.js`.
+
+If you are using the default setup from create-react-app, this option is set to
+`src/setupTests.js`. You should create this file if it doesn't exist and put the
+setup code there.
+
+```javascript
+// jest.config.js
+module.exports = {
+  setupTestFrameworkScriptFile: require.resolve('./jest.setup.js'),
+  // ... other options ...
+}
+```
+
+```javascript
+// jest.setup.js
+
+// add some helpful assertions
+import 'jest-dom/extend-expect'
+
+// this is basically: afterEach(cleanup)
+import 'react-testing-library/cleanup-after-each'
+```
+
+</details>
+
+## Custom Render
+
+It's often useful to define a custom render method that includes things like
+global context providers, data stores, etc. To make this available globally, one
+approach is to define a utility file that re-exports everything from
+`react-testing-library`. You can replace react-testing-library with this file in
+all your imports. See [below](#comfiguring-jest-with-test-utils) for a way to
+make your test util file accessible without using relative paths.
+
+The example below sets up data providers using the
+[`wrapper`](api.md#render-options) option to `render`.
+
+```diff
+// my-component.test.js
+- import { render, fireEvent } from 'react-testing-library';
++ import { render, fireEvent } from '../test-utils';
+```
+
+```js
+// test-utils.js
+import { render } from 'react-testing-library'
+import { ThemeProvider } from 'my-ui-lib'
+import { TranslationProvider } from 'my-i18n-lib'
+import defaultStrings from 'i18n/en-x-default'
+
+const AllTheProviders = ({ children }) => {
+  return (
+    <ThemeProvider theme="light">
+      <TranslationProvider messages={defaultStrings}>
+        {children}
+      </TranslationProvider>
+    </ThemeProvider>
+  )
+}
+
+const customRender = (ui, options) =>
+  render(ui, { wrapper: AllTheProviders, ...options })
+
+// re-export everything
+export * from 'react-testing-library'
+
+// override render method
+export { customRender as render }
+```
+
+> **Note**
+>
+> Babel versions lower than 7 throw an error when trying to override the named
+> export in the example above. See
+> [#169](https://github.com/kentcdodds/react-testing-library/issues/169) and the
+> workaround below.
+
+<details>
+<summary>Workaround for Babel 6</summary>
+
+You can use CommonJS modules instead of ES modules, which should work in Node:
+
+```js
+// test-utils.js
+const rtl = require('react-testing-library')
+
+const customRender = (ui, options) =>
+  rtl.render(ui, {
+    myDefaultOption: 'something',
+    ...options,
+  })
+
+module.exports = {
+  ...rtl,
+  render: customRender,
+}
+```
+
+</details>
+
+### Configuring Jest with Test Utils
+
+To make your custom test file accessible in your Jest test files without using
+relative imports (`../../test-utils`), add the folder containing the file to the
+Jest `moduleDirectories` option.
+
+This will make all the `.js` files in the test-utils directory importable
+without `../`.
+
+```diff
+// my-component.test.js
+- import { render, fireEvent } from '../test-utils';
++ import { render, fireEvent } from 'test-utils';
+```
+
+```diff
+// jest.config.js
+module.exports = {
+  moduleDirectories: [
+    'node_modules',
++   // add the directory with the test-utils.js file, for example:
++   'utils', // a utility folder
++    __dirname, // the root directory
+  ],
+  // ... other options ...
+}
+```
+
+### Jest and Create React App
+
+If your project is based on top of Create React App, to make the `test-utils`
+file accessible without using relative imports, you just need to create a `.env`
+file in the root of your project with the following configuration:
+
+```
+// Create React App project structure
+
+$ app
+.
+├── .env
+├── src
+│   ├── utils
+│   │  └── test-utils.js
+│
+```
+
+```
+// .env
+
+// example if your utils folder is inside the /src directory.
+NODE_PATH=src/utils
+```
+
+## Using without Jest
+
+If you're running your tests in the browser bundled with webpack (or similar)
+then `react-testing-library` should work out of the box for you. However, most
+people using react-testing-library are using it with the Jest testing framework
+with the `testEnvironment` set to `jest-environment-jsdom` (which is the default
+configuration with Jest).
+
+`jsdom` is a pure JavaScript implementation of the DOM and browser APIs that
+runs in node. If you're not using Jest and you would like to run your tests in
+Node, then you must install jsdom yourself. There's also a package called
+`jsdom-global` which can be used to setup the global environment to simulate the
+browser APIs.
+
+First, install `jsdom` and `jsdom-global`.
+
+```
+npm install --save-dev jsdom jsdom-global
+```
+
+With mocha, the test command would look something like this:
+
+```
+mocha --require jsdom-global/register
+```
+
+Note, depending on the version of Node you're running, you may also need to
+install @babel/polyfill (if you're using babel 7) or babel-polyfill (for babel
+6).

--- a/website/pages/en/preact.js
+++ b/website/pages/en/preact.js
@@ -37,10 +37,10 @@ class HomeSplash extends React.Component {
 
     const ProjectTitle = () => (
       <div>
-        <h2 className="projectTitle">React Testing Library</h2>
+        <h2 className="projectTitle">Preact Testing Library</h2>
         <div className="projectTaglineWrapper">
           <p className="projectTagline">
-            Simple and complete React DOM testing utilities that encourage good
+            Simple and complete Preact DOM testing utilities that encourage good
             testing practices
           </p>
         </div>
@@ -69,7 +69,7 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle siteConfig={siteConfig} />
           <PromoSection>
-            <Button href={docUrl('react-testing-library/intro')}>
+            <Button href={docUrl('preact-testing-library/intro')}>
               Read the Docs
             </Button>
           </PromoSection>
@@ -109,7 +109,7 @@ class Index extends React.Component {
             </i>
           </p>
           <MarkdownBlock>
-            `npm install --save-dev react-testing-library`
+            `npm install --save-dev preact-testing-library`
           </MarkdownBlock>
         </div>
       </Container>
@@ -122,7 +122,7 @@ class Index extends React.Component {
             {
               title: '',
               content:
-                "## The Problem \n - You want tests for your React components that avoid including implementation details and rather focus on making your tests give you the confidence for which they are intended. \n - You want your tests to be maintainable so refactors _(changes to implementation but not functionality)_ don't break your tests and slow you and your team down.",
+                "## The Problem \n - You want tests for your Preact components that avoid including implementation details and rather focus on making your tests give you the confidence for which they are intended. \n - You want your tests to be maintainable so refactors _(changes to implementation but not functionality)_ don't break your tests and slow you and your team down.",
               image: `${baseUrl}img/interrobang-128x128.png`,
               imageAlt: 'The problem (picture of a question mark)',
               imageAlign: 'left',
@@ -141,7 +141,7 @@ class Index extends React.Component {
             imageAlign: 'right',
             imageAlt: 'The solution (picture of a star)',
             content:
-              '## The Solution \n `react-testing-library` is a very light-weight solution for testing React components. It provides utility functions on top of react-dom and react-dom/test-utils in a way that encourages better testing practices. Its primary guiding principle is: \n > The more your tests resemble the way your software is used, the more confidence they can give you.',
+              '## The Solution \n `preact-testing-library` is a very light-weight solution for testing Preact components. It provides utility functions on top of react-dom and react-dom/test-utils in a way that encourages better testing practices. Its primary guiding principle is: \n > The more your tests resemble the way your software is used, the more confidence they can give you. \n\n This library is heavily inspired by [react-testing-library](/react).',
           },
         ]}
       </Block>
@@ -173,7 +173,7 @@ class Index extends React.Component {
             },
             {
               content:
-                '`react-testing-library` is an opinionated alternative to libraries like Enzyme that provide too many ways to avoid testing like a user',
+                '`preact-testing-library` is an opinionated alternative to libraries like Enzyme that provide too many ways to avoid testing like a user',
               image: `${baseUrl}img/vs-128x128.png`,
               imageAlign: 'top',
               title: 'Alternative to Enzyme',

--- a/website/pages/en/preact.js
+++ b/website/pages/en/preact.js
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react')
+
+const CompLibrary = require('../../core/CompLibrary.js')
+
+const MarkdownBlock = CompLibrary.MarkdownBlock /* Used to read markdown */
+const Container = CompLibrary.Container
+const GridBlock = CompLibrary.GridBlock
+
+class HomeSplash extends React.Component {
+  render() {
+    const { siteConfig, language = '' } = this.props
+    const { baseUrl, docsUrl } = siteConfig
+    const docsPart = `${docsUrl ? `${docsUrl}/` : ''}`
+    const langPart = `${language ? `${language}/` : ''}`
+    const docUrl = doc => `${baseUrl}${docsPart}${langPart}${doc}`
+
+    const SplashContainer = props => (
+      <div className="homeContainer">
+        <div className="homeSplashFade">
+          <div className="wrapper homeWrapper">{props.children}</div>
+        </div>
+      </div>
+    )
+
+    const Logo = props => (
+      <div className="projectLogo">
+        <img src={props.img_src} alt="Project Logo" />
+      </div>
+    )
+
+    const ProjectTitle = () => (
+      <div>
+        <h2 className="projectTitle">React Testing Library</h2>
+        <div className="projectTaglineWrapper">
+          <p className="projectTagline">
+            Simple and complete React DOM testing utilities that encourage good
+            testing practices
+          </p>
+        </div>
+      </div>
+    )
+
+    const PromoSection = props => (
+      <div className="section promoSection">
+        <div className="promoRow">
+          <div className="pluginRowBlock">{props.children}</div>
+        </div>
+      </div>
+    )
+
+    const Button = props => (
+      <div className="pluginWrapper buttonWrapper">
+        <a className="button" href={props.href} target={props.target}>
+          {props.children}
+        </a>
+      </div>
+    )
+
+    return (
+      <SplashContainer>
+        <Logo img_src={`${baseUrl}img/react-128x128.png`} />
+        <div className="inner">
+          <ProjectTitle siteConfig={siteConfig} />
+          <PromoSection>
+            <Button href={docUrl('react-testing-library/intro')}>
+              Read the Docs
+            </Button>
+          </PromoSection>
+        </div>
+      </SplashContainer>
+    )
+  }
+}
+
+class Index extends React.Component {
+  render() {
+    const { config: siteConfig, language = '' } = this.props
+    const { baseUrl } = siteConfig
+
+    const Block = props => (
+      <Container
+        padding={['bottom', 'top']}
+        id={props.id}
+        background={props.background}
+      >
+        <GridBlock
+          align={props.align || 'center'}
+          imageAlign={props.imageAlign || 'center'}
+          contents={props.children}
+          layout={props.layout}
+        />
+      </Container>
+    )
+
+    const FeatureCallout = () => (
+      <Container className="" background={'light'} padding={['top', 'bottom']}>
+        <div style={{ textAlign: 'center' }}>
+          <p>
+            <i>
+              The more your tests resemble the way your software is used, <br />
+              the more confidence they can give you.
+            </i>
+          </p>
+          <MarkdownBlock>
+            `npm install --save-dev react-testing-library`
+          </MarkdownBlock>
+        </div>
+      </Container>
+    )
+
+    const Problem = () => (
+      <React.Fragment>
+        <Block background={'light'} align="left">
+          {[
+            {
+              title: '',
+              content:
+                "## The Problem \n - You want tests for your React components that avoid including implementation details and rather focus on making your tests give you the confidence for which they are intended. \n - You want your tests to be maintainable so refactors _(changes to implementation but not functionality)_ don't break your tests and slow you and your team down.",
+              image: `${baseUrl}img/interrobang-128x128.png`,
+              imageAlt: 'The problem (picture of a question mark)',
+              imageAlign: 'left',
+            },
+          ]}
+        </Block>
+      </React.Fragment>
+    )
+
+    const Solution = () => (
+      <Block background={null} align="left">
+        {[
+          {
+            title: '',
+            image: `${baseUrl}img/star-128x128.png`,
+            imageAlign: 'right',
+            imageAlt: 'The solution (picture of a star)',
+            content:
+              '## The Solution \n `react-testing-library` is a very light-weight solution for testing React components. It provides utility functions on top of react-dom and react-dom/test-utils in a way that encourages better testing practices. Its primary guiding principle is: \n > The more your tests resemble the way your software is used, the more confidence they can give you.',
+          },
+        ]}
+      </Block>
+    )
+
+    const Features = () => (
+      <React.Fragment>
+        <Block layout="twoColumn">
+          {[
+            {
+              content:
+                'Tests only break when your app breaks, not implementation details',
+              image: `${baseUrl}img/wrench-128x128.png`,
+              imageAlign: 'top',
+              title: 'Write Maintainable Tests',
+            },
+            {
+              content: 'Interact with your app the same way as your users',
+              image: `${baseUrl}img/check-128x128.png`,
+              imageAlign: 'top',
+              title: 'Develop with Confidence',
+            },
+            {
+              content:
+                'Built-in selectors use semantic HTML and ARIA roles to help you write inclusive code',
+              image: `${baseUrl}img/tada-128x128.png`,
+              imageAlign: 'top',
+              title: 'Accessible by Default',
+            },
+            {
+              content:
+                '`react-testing-library` is an opinionated alternative to libraries like Enzyme that provide too many ways to avoid testing like a user',
+              image: `${baseUrl}img/vs-128x128.png`,
+              imageAlign: 'top',
+              title: 'Alternative to Enzyme',
+            },
+          ]}
+        </Block>
+      </React.Fragment>
+    )
+
+    return (
+      <div>
+        <HomeSplash siteConfig={siteConfig} language={language} />
+        <div className="mainContainer">
+          <FeatureCallout />
+          <Features />
+          <Problem />
+          <Solution />
+        </div>
+      </div>
+    )
+  }
+}
+
+module.exports = Index

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -32,6 +32,17 @@
           "react-testing-library/faq"
         ]
       },
+      {
+        "type": "subcategory",
+        "label": "Preact Testing Library",
+        "ids": [
+          "preact-testing-library/intro",
+          "preact-testing-library/example-intro",
+          "preact-testing-library/setup",
+          "preact-testing-library/api",
+          "preact-testing-library/faq"
+        ]
+      },
       "cypress-testing-library/intro",
       "vue-testing-library/intro",
       "angular-testing-library/intro",


### PR DESCRIPTION
Basically, I copied react-testing-library docs and replaced some of it with content from https://github.com/antsmartian/preact-testing-library

Related to https://github.com/antsmartian/preact-testing-library/issues/11

Needs a review, updates, and probably a consideration if all of this is even needed. 