### PR TITLE
Removed duplicate call to code-block-buttons.css in siteConfig.js

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -127,7 +127,6 @@ const siteConfig = {
 
   stylesheets: [
     'https://fonts.googleapis.com/css?family=IBM+Plex+Mono:500,700|Source+Code+Pro:500,700|Source+Sans+Pro:400,400i,700',
-    '/css/code-block-buttons.css',
   ],
 
   /* Custom fonts for website */


### PR DESCRIPTION
As discussed in issue #93 
I have removed the duplicate call to the css `code-block-buttons.css` as it was giving a 404 error in browser console after compiling.
the above mentioned css is compiled and already a part of `main.css` and hence the call was duplicate and therefore is being removed here.
Before:
<img width="1277" alt="Screenshot 2019-04-29 at 12 27 44 PM" src="https://user-images.githubusercontent.com/35738138/56880408-32a8fa00-6a7a-11e9-8a87-472eb1e00df3.png">
After:
<img width="1280" alt="Screenshot 2019-04-29 at 12 28 03 PM" src="https://user-images.githubusercontent.com/35738138/56880423-3e94bc00-6a7a-11e9-9659-66e9c3128d04.png">

/cc: @alexkrolick 
(Fixes #93)