### PR TITLE
Fixing .all-contributorsrc to work similar to rest of the projects.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4,6 +4,7 @@
   ],
   "imageSize": 100,
   "commit": false,
+  "commitConvention": "angular",
   "contributors": [
     {
       "login": "kentcdodds",


### PR DESCRIPTION
As discussed in #78 
After merging of one contribution, The .all-contributorsrc file now follows the same convention as that of all other projects in testing-library.
I feel this will be sufficient for the setup and we can after this merge setup the issue which we can dedicate to add contributors. 🥇 

/cc: @alexkrolick 