### PR TITLE
Fix `getByAltText` examples

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -308,7 +308,7 @@ as it's deprecated).
 import { getByAltText } from 'dom-testing-library'
 
 const container = document.body
-const incrediblesPosterImg = getByAltText(container, /incredibles.*png$/i)
+const incrediblesPosterImg = getByAltText(container, 'Incredibles 2 Poster')
 ```
 
 <!--React-->
@@ -317,13 +317,13 @@ const incrediblesPosterImg = getByAltText(container, /incredibles.*png$/i)
 import { render } from 'react-testing-library'
 
 const { getByAltText } = render(<MyComponent />)
-const incrediblesPosterImg = getByAltText(/incredibles.*png$/i)
+const incrediblesPosterImg = getByAltText('Incredibles 2 Poster')
 ```
 
 <!--Cypress-->
 
 ```js
-cy.getByAltText(/incredibles.*png$/i).should('exist')
+cy.getByAltText('Incredibles 2 Poster').should('exist')
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -308,7 +308,7 @@ as it's deprecated).
 import { getByAltText } from 'dom-testing-library'
 
 const container = document.body
-const incrediblesPosterImg = getByAltText(container, 'Incredibles 2 Poster')
+const incrediblesPosterImg = getByAltText(container, /incredibles.*? poster/i)
 ```
 
 <!--React-->
@@ -317,13 +317,13 @@ const incrediblesPosterImg = getByAltText(container, 'Incredibles 2 Poster')
 import { render } from 'react-testing-library'
 
 const { getByAltText } = render(<MyComponent />)
-const incrediblesPosterImg = getByAltText('Incredibles 2 Poster')
+const incrediblesPosterImg = getByAltText(/incredibles.*? poster/i)
 ```
 
 <!--Cypress-->
 
 ```js
-cy.getByAltText('Incredibles 2 Poster').should('exist')
+cy.getByAltText(/incredibles.*? poster/i).should('exist')
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
Fixes #116

I replaced `/incredibles.*png$/i` with `'Incredibles 2 Poster'`, which should match the `alt` attribute in the example markup.