### PR TITLE
docs: fix import in render function queries option example

### DIFF
--- a/docs/react-testing-library/api.md
+++ b/docs/react-testing-library/api.md
@@ -100,7 +100,7 @@ merged.
 ```js
 // Example, a function to traverse table contents
 import * as tableQueries from 'my-table-query-libary'
-import queries from '@testing-library/react'
+import { queries } from '@testing-library/react'
 
 const { getByRowColumn, getByText } = render(<MyTable />, {
   queries: { ...queries, ...tableQueries },


### PR DESCRIPTION
I was looking at adding a custom data attribute query and found these docs, but RTL doesn't contain a default export so importing queries as in the example doesn't work. Just added a quick fix for the import.