### PR TITLE
docs: add custom queries example to custom render docs

### DIFF
--- a/docs/dom-testing-library/api-helpers.md
+++ b/docs/dom-testing-library/api-helpers.md
@@ -56,6 +56,12 @@ module.exports = {
 > adding `queries` to the options config object. See the render
 > [options](/docs/react-testing-library/api#render-options).
 
+## `buildQueries`
+
+The `buildQueries` helper allows you to easily create your custom query with all standard [variants](api-queries.md) of queries in testing-library.
+
+See the 'Customize queries globally with custom render' section  of the [custom render guide](/docs/react-testing-library/setup#custom-render) for example usage.
+
 ### Using other assertion libraries
 
 If you're not using jest, you may be able to find a similar set of custom

--- a/docs/dom-testing-library/api-helpers.md
+++ b/docs/dom-testing-library/api-helpers.md
@@ -58,9 +58,9 @@ module.exports = {
 
 ## `buildQueries`
 
-The `buildQueries` helper allows you to easily create your custom query with all standard [variants](api-queries.md) of queries in testing-library.
+The `buildQueries` helper allows you to create custom queres with all standard [variants](api-queries.md) of queries in testing-library.
 
-See the 'Customize queries globally with custom render' section  of the [custom render guide](/docs/react-testing-library/setup#custom-render) for example usage.
+See the [Add custom queries](/docs/react-testing-library/setup#add-custom-queries) section of the custom render guide for example usage.
 
 ### Using other assertion libraries
 

--- a/docs/react-testing-library/setup.md
+++ b/docs/react-testing-library/setup.md
@@ -147,31 +147,76 @@ module.exports = {
 <details>
 <summary>Customize queries globally with custom render</summary>
 
-You can override and append queries via the render function by passing a [`queries`](api.md#render-options) option.
+In the example below, a new set of query variants are created for getting
+elements by `data-cy`, an attribute used and recommended by [Cypress.io](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements).
 
-You can define your own custom queries as described in the example in the [Helpers API](api-helpers.md) documentation.
+It is worth noting that generally you should not need to use this feature of
+react-testing-library and, where you do use it, you should really consider whether
+your new queries encourage you to test in a user-centric way, without testing
+implementation detail.
+
+`data-testid` is supported by Cypress.io, so even in this case, you would not technically
+need to create a new set of queries and you could just replace `data-cy` with
+`data-testid` attributes throughout your project. 
+
+You can define your own custom queries as described in the example in the 
+[Helpers API](/doc/dom-testing-library/api-helpers.md) documentation, or via the
+ [`buildQueries`](/doc/dom-testing-library/api-helpers#buildQueries) helper:
+
+```js
+// custom-queries.js
+import { queryHelpers, buildQueries } from '@testing-library/react';
+
+const queryAllByDataCy = (...args) => 
+  queryHelpers.queryAllByAttribute('data-cy', ...args);
+
+const getMultipleError = (c, dataCyValue) => (
+  `Found multiple elements with the data-cy attribute of: ${dataCyValue}`
+);
+const getMissingError = (c, dataCyValue) => (
+  `Unable to find an element with the data-cy attribute of: ${dataCyValue}`
+);
+
+const [
+  queryByDataCy,
+  getAllByDataCy,
+  getByDataCy,
+  findAllByDataCy,
+  findByDataCy
+] = buildQueries(
+  queryAllByDataCy,
+  getMultipleError,
+  getMissingError,
+);
+
+export {
+  queryByDataCy,
+  queryAllByDataCy,
+  getByDataCy,
+  getAllByDataCy,
+  findAllByDataCy,
+  findByDataCy,
+};
+```
+
+You can then override and append queries via the render function by passing a 
+[`queries`](api.md#render-options) option.
 
 If you want to add custom queries globally, you can do this by defining a custom render method:
 
 ```js
 // test-utils.js
-import { render, queries, queryHelpers } from '@testing-library/react'
-
-const customQueries = {
-  getByDataCy: queryHelpers.queryByAttribute.bind(
-    null,
-    'data-cy'
-  ),
-};
+import { render, queries, queryHelpers } from '@testing-library/react';
+import * as customQueries from './custom-queries';
 
 const customRender = (ui, options) =>
-  render(ui, { queries: { ...queries, ...customQueries } })
+  render(ui, { queries: { ...queries, ...customQueries } });
 
 // re-export everything
-export * from '@testing-library/react'
+export * from '@testing-library/react';
 
 // override render method
-export { customRender as render }
+export { customRender as render };
 ```
 
 You can then use your custom queries as you would any other query:

--- a/docs/react-testing-library/setup.md
+++ b/docs/react-testing-library/setup.md
@@ -144,6 +144,47 @@ module.exports = {
 
 </details>
 
+<details>
+<summary>Customize queries globally with custom render</summary>
+
+You can override and append queries via the render function by passing a [`queries`](api.md#render-options) option.
+
+You can define your own custom queries as described in the example in the [Helpers API](api-helpers.md) documentation.
+
+If you want to add custom queries globally, you can do this by defining a custom render method:
+
+```js
+// test-utils.js
+import { render, queries, queryHelpers } from '@testing-library/react'
+
+const customQueries = {
+  getByDataCy: queryHelpers.queryByAttribute.bind(
+    null,
+    'data-cy'
+  ),
+};
+
+const customRender = (ui, options) =>
+  render(ui, { queries: { ...queries, ...customQueries } })
+
+// re-export everything
+export * from '@testing-library/react'
+
+// override render method
+export { customRender as render }
+```
+
+You can then use your custom queries as you would any other query:
+
+```js
+const { getByDataCy } = render(
+  <Component />
+);
+
+expect(getByDataCy('my-component')).toHaveTextContent('Hello');
+```
+</details>
+
 ### Configuring Jest with Test Utils
 
 To make your custom test file accessible in your Jest test files without using

--- a/docs/react-testing-library/setup.md
+++ b/docs/react-testing-library/setup.md
@@ -146,36 +146,37 @@ module.exports = {
 
 <details>
 <summary>Customize queries globally with custom render</summary>
+  
+> **Note**
+>
+> Generally you should not need to create custom attributes for
+> react-testing-library. Where you do use it, you should consider whether your
+> new queries encourage you to test in a user-centric way, without testing
+> implementation details.
 
 In the example below, a new set of query variants are created for getting
-elements by `data-cy`, an attribute used and recommended by [Cypress.io](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements).
+elements by `data-cy`, a "test ID" attribute recommended in the
+[Cypress.io](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements)
+documentation. Note that `data-testid` is supported by Cypress.io, so even in
+this case, you would not technically need to create a new set of queries and you
+could just replace `data-cy` with `data-testid` attributes throughout your
+project.
 
-It is worth noting that generally you should not need to use this feature of
-react-testing-library and, where you do use it, you should really consider whether
-your new queries encourage you to test in a user-centric way, without testing
-implementation detail.
-
-`data-testid` is supported by Cypress.io, so even in this case, you would not technically
-need to create a new set of queries and you could just replace `data-cy` with
-`data-testid` attributes throughout your project. 
-
-You can define your own custom queries as described in the example in the 
+You can define your own custom queries as described in the example in the
 [Helpers API](/doc/dom-testing-library/api-helpers.md) documentation, or via the
- [`buildQueries`](/doc/dom-testing-library/api-helpers#buildQueries) helper:
+[`buildQueries`](/doc/dom-testing-library/api-helpers#buildQueries) helper:
 
 ```js
 // custom-queries.js
-import { queryHelpers, buildQueries } from '@testing-library/react';
+import { queryHelpers, buildQueries } from "@testing-library/react";
 
-const queryAllByDataCy = (...args) => 
-  queryHelpers.queryAllByAttribute('data-cy', ...args);
+const queryAllByDataCy = (...args) =>
+  queryHelpers.queryAllByAttribute("data-cy", ...args);
 
-const getMultipleError = (c, dataCyValue) => (
-  `Found multiple elements with the data-cy attribute of: ${dataCyValue}`
-);
-const getMissingError = (c, dataCyValue) => (
-  `Unable to find an element with the data-cy attribute of: ${dataCyValue}`
-);
+const getMultipleError = (c, dataCyValue) =>
+  `Found multiple elements with the data-cy attribute of: ${dataCyValue}`;
+const getMissingError = (c, dataCyValue) =>
+  `Unable to find an element with the data-cy attribute of: ${dataCyValue}`;
 
 const [
   queryByDataCy,
@@ -183,11 +184,7 @@ const [
   getByDataCy,
   findAllByDataCy,
   findByDataCy
-] = buildQueries(
-  queryAllByDataCy,
-  getMultipleError,
-  getMissingError,
-);
+] = buildQueries(queryAllByDataCy, getMultipleError, getMissingError);
 
 export {
   queryByDataCy,
@@ -195,14 +192,15 @@ export {
   getByDataCy,
   getAllByDataCy,
   findAllByDataCy,
-  findByDataCy,
+  findByDataCy
 };
 ```
 
 You can then override and append queries via the render function by passing a 
 [`queries`](api.md#render-options) option.
 
-If you want to add custom queries globally, you can do this by defining a custom render method:
+If you want to add custom queries globally, you can do this by defining a custom
+render method:
 
 ```js
 // test-utils.js

--- a/docs/react-testing-library/setup.md
+++ b/docs/react-testing-library/setup.md
@@ -96,7 +96,7 @@ import defaultStrings from 'i18n/en-x-default'
 
 const AllTheProviders = ({ children }) => {
   return (
-    <ThemeProvider theme="light">
+    <ThemeProvider theme='light'>
       <TranslationProvider messages={defaultStrings}>
         {children}
       </TranslationProvider>
@@ -144,9 +144,8 @@ module.exports = {
 
 </details>
 
-<details>
-<summary>Customize queries globally with custom render</summary>
-  
+### Add custom queries
+
 > **Note**
 >
 > Generally you should not need to create custom attributes for
@@ -154,37 +153,40 @@ module.exports = {
 > new queries encourage you to test in a user-centric way, without testing
 > implementation details.
 
-In the example below, a new set of query variants are created for getting
-elements by `data-cy`, a "test ID" attribute recommended in the
-[Cypress.io](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements)
-documentation. Note that `data-testid` is supported by Cypress.io, so even in
-this case, you would not technically need to create a new set of queries and you
-could just replace `data-cy` with `data-testid` attributes throughout your
-project.
-
 You can define your own custom queries as described in the example in the
 [Helpers API](/doc/dom-testing-library/api-helpers.md) documentation, or via the
-[`buildQueries`](/doc/dom-testing-library/api-helpers#buildQueries) helper:
+[`buildQueries`](/doc/dom-testing-library/api-helpers#buildQueries) helper. Then
+you can use the in any render call using the `queries` option. To make the
+custom queries available globally, you can add them to your custom render method
+as shown below.
+
+In the example below, a new set of query variants are created for getting
+elements by `data-cy`, a "test ID" convention mentioned in the
+[Cypress.io](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements)
+documentation.
 
 ```js
 // custom-queries.js
-import { queryHelpers, buildQueries } from "@testing-library/react";
+import { queryHelpers, buildQueries } from '@testing-library/react'
 
+// The queryAllByAttribute is a shortcut for attribute-based matchers
+// You can also use document.querySelector or a combination of existing
+// testing library utilities to find matching nodes for your query
 const queryAllByDataCy = (...args) =>
-  queryHelpers.queryAllByAttribute("data-cy", ...args);
+  queryHelpers.queryAllByAttribute('data-cy', ...args)
 
 const getMultipleError = (c, dataCyValue) =>
-  `Found multiple elements with the data-cy attribute of: ${dataCyValue}`;
+  `Found multiple elements with the data-cy attribute of: ${dataCyValue}`
 const getMissingError = (c, dataCyValue) =>
-  `Unable to find an element with the data-cy attribute of: ${dataCyValue}`;
+  `Unable to find an element with the data-cy attribute of: ${dataCyValue}`
 
 const [
   queryByDataCy,
   getAllByDataCy,
   getByDataCy,
   findAllByDataCy,
-  findByDataCy
-] = buildQueries(queryAllByDataCy, getMultipleError, getMissingError);
+  findByDataCy,
+] = buildQueries(queryAllByDataCy, getMultipleError, getMissingError)
 
 export {
   queryByDataCy,
@@ -192,40 +194,39 @@ export {
   getByDataCy,
   getAllByDataCy,
   findAllByDataCy,
-  findByDataCy
-};
+  findByDataCy,
+}
 ```
 
-You can then override and append queries via the render function by passing a 
-[`queries`](api.md#render-options) option.
+You can then override and append the new queries via the render function by
+passing a [`queries`](api.md#render-options) option.
 
 If you want to add custom queries globally, you can do this by defining a custom
 render method:
 
 ```js
 // test-utils.js
-import { render, queries, queryHelpers } from '@testing-library/react';
-import * as customQueries from './custom-queries';
+import { render, queries, queryHelpers } from '@testing-library/react'
+import * as customQueries from './custom-queries'
 
 const customRender = (ui, options) =>
-  render(ui, { queries: { ...queries, ...customQueries } });
+  render(ui, { queries: { ...queries, ...customQueries } })
 
 // re-export everything
-export * from '@testing-library/react';
+export * from '@testing-library/react'
 
 // override render method
-export { customRender as render };
+export { customRender as render }
 ```
 
 You can then use your custom queries as you would any other query:
 
 ```js
-const { getByDataCy } = render(
-  <Component />
-);
+const { getByDataCy } = render(<Component />)
 
-expect(getByDataCy('my-component')).toHaveTextContent('Hello');
+expect(getByDataCy('my-component')).toHaveTextContent('Hello')
 ```
+
 </details>
 
 ### Configuring Jest with Test Utils


### PR DESCRIPTION
Following on from my previous PR (#151) and having noticed the discussion in #80:

* Adding an example for adding custom queries globally via creating a custom render function.

In the example, I've create a data attribute selector for `data-cy` as this is one of the attributes recommended by Cypress. I think in reality I would favour replacing `data-cy` globally throughout my projects with `data-testid`, but this may be useful for some people not willing to refactor out `data-cy`, or similar, at the moment.