### PR TITLE
change text cursor to pointer cursor

### DIFF
--- a/docs/react-testing-library/faq.md
+++ b/docs/react-testing-library/faq.md
@@ -8,13 +8,9 @@ to React testing
 
 <details>
   
-<style>
- #summary {
-    pointer: cursor;
-  }
-</style>
 
-<summary id="summary">How do I test input onChange handlers?</summary>
+
+<summary>How do I test input onChange handlers?</summary>
 
 TL;DR:
 [Go to the `on-change.js` example](https://codesandbox.io/s/github/kentcdodds/react-testing-library-examples/tree/master/?module=%2Fsrc%2F__tests__%2Fon-change.js&previewwindow=tests)
@@ -71,7 +67,7 @@ as part of the `change` method call.
 
 <details>
 
-<summary id="summary">Can I write unit tests with this library?</summary>
+<summary >Can I write unit tests with this library?</summary>
 
 Definitely yes! You can write unit and integration tests with this library. See
 below for more on how to mock dependencies (because this library intentionally
@@ -88,7 +84,7 @@ As you write your tests, keep in mind:
 
 <details>
 
-<summary id="summary">If I can't use shallow rendering, how do I mock out components in tests?</summary>
+<summary >If I can't use shallow rendering, how do I mock out components in tests?</summary>
 
 In general, you should avoid mocking out components (see
 [the Guiding Principles section](guiding-principles.md)). However if you need
@@ -139,7 +135,7 @@ Learn more about how Jest mocks work from my blog post:
 
 <details>
 
-<summary id="summary">What about enzyme is "bloated with complexity and features" and "encourage
+<summary >What about enzyme is "bloated with complexity and features" and "encourage
 poor testing practices"?</summary>
 
 Most of the damaging features have to do with encouraging testing implementation
@@ -167,7 +163,7 @@ react components.
 
 <details>
 
-<summary id="summary">Why isn't snapshot diffing working?</summary>
+<summary >Why isn't snapshot diffing working?</summary>
 
 If you use the [snapshot-diff](https://github.com/jest-community/snapshot-diff)
 library to save snapshot diffs, it won't work out of the box because this

--- a/docs/react-testing-library/faq.md
+++ b/docs/react-testing-library/faq.md
@@ -67,7 +67,7 @@ as part of the `change` method call.
 
 <details>
 
-<summary >Can I write unit tests with this library?</summary>
+<summary>Can I write unit tests with this library?</summary>
 
 Definitely yes! You can write unit and integration tests with this library. See
 below for more on how to mock dependencies (because this library intentionally
@@ -84,7 +84,7 @@ As you write your tests, keep in mind:
 
 <details>
 
-<summary >If I can't use shallow rendering, how do I mock out components in tests?</summary>
+<summary>If I can't use shallow rendering, how do I mock out components in tests?</summary>
 
 In general, you should avoid mocking out components (see
 [the Guiding Principles section](guiding-principles.md)). However if you need
@@ -135,7 +135,7 @@ Learn more about how Jest mocks work from my blog post:
 
 <details>
 
-<summary >What about enzyme is "bloated with complexity and features" and "encourage
+<summary>What about enzyme is "bloated with complexity and features" and "encourage
 poor testing practices"?</summary>
 
 Most of the damaging features have to do with encouraging testing implementation
@@ -163,7 +163,7 @@ react components.
 
 <details>
 
-<summary >Why isn't snapshot diffing working?</summary>
+<summary>Why isn't snapshot diffing working?</summary>
 
 If you use the [snapshot-diff](https://github.com/jest-community/snapshot-diff)
 library to save snapshot diffs, it won't work out of the box because this

--- a/docs/react-testing-library/faq.md
+++ b/docs/react-testing-library/faq.md
@@ -7,8 +7,14 @@ See also the [main FAQ](dom-testing-library/faq.md) for questions not specific
 to React testing
 
 <details>
+  
+<style>
+ #summary {
+    pointer: cursor;
+  }
+</style>
 
-<summary>How do I test input onChange handlers?</summary>
+<summary id="summary">How do I test input onChange handlers?</summary>
 
 TL;DR:
 [Go to the `on-change.js` example](https://codesandbox.io/s/github/kentcdodds/react-testing-library-examples/tree/master/?module=%2Fsrc%2F__tests__%2Fon-change.js&previewwindow=tests)
@@ -65,7 +71,7 @@ as part of the `change` method call.
 
 <details>
 
-<summary>Can I write unit tests with this library?</summary>
+<summary id="summary">Can I write unit tests with this library?</summary>
 
 Definitely yes! You can write unit and integration tests with this library. See
 below for more on how to mock dependencies (because this library intentionally
@@ -82,7 +88,7 @@ As you write your tests, keep in mind:
 
 <details>
 
-<summary>If I can't use shallow rendering, how do I mock out components in tests?</summary>
+<summary id="summary">If I can't use shallow rendering, how do I mock out components in tests?</summary>
 
 In general, you should avoid mocking out components (see
 [the Guiding Principles section](guiding-principles.md)). However if you need
@@ -133,7 +139,7 @@ Learn more about how Jest mocks work from my blog post:
 
 <details>
 
-<summary>What about enzyme is "bloated with complexity and features" and "encourage
+<summary id="summary">What about enzyme is "bloated with complexity and features" and "encourage
 poor testing practices"?</summary>
 
 Most of the damaging features have to do with encouraging testing implementation
@@ -161,7 +167,7 @@ react components.
 
 <details>
 
-<summary>Why isn't snapshot diffing working?</summary>
+<summary id="summary">Why isn't snapshot diffing working?</summary>
 
 If you use the [snapshot-diff](https://github.com/jest-community/snapshot-diff)
 library to save snapshot diffs, it won't work out of the box because this

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -92,7 +92,7 @@ a {
   border-top: none;
 }
 
-details summary {
+details > summary {
   cursor: pointer; 
 }
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -92,6 +92,10 @@ a {
   border-top: none;
 }
 
+details summary {
+  cursor: pointer; 
+}
+
 /* Responsive */
 
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {


### PR DESCRIPTION
hovering over each question in the faq, results in the cursor changing to a text cursor. I have added a simply style attribute of pointer: cursor and id to each summary.