### PR TITLE
Fix a capitalization error

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -140,7 +140,7 @@ case, you can provide a `selector` in the options:
 
 ```js
 const container = document.body
-const inputNode = getByLabelText(container, 'username', {
+const inputNode = getByLabelText(container, 'Username', {
   selector: 'input',
 })
 ```


### PR DESCRIPTION
Changed the TextMatch from `username` to `Username` in the `getByLabelText()` example.

I believe the method uses exact match by default, which would make the test fail as the label it is looking for has a value of `Username`.