### PR TITLE
run format command before build for consistency

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,7 @@
   publish = "website/build/testing-library-docs"
 
   # Default build command.
-  command = "cd website; npm install; npm run build"
+  command = "cd website; npm install; npm run format-docs; npm run build"
 
 # React root to React landing page
 [[redirects]]


### PR DESCRIPTION
Since a lot of people are committing on GitHub directly, there are lots of pages that haven't had the format command run over them. This PR adds the format command before pushing to netlify. This won't check in changes, but it will catch formatting inconsistency in code blocks when published.