### PR TITLE
Fix links to guiding-principles.md

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -626,7 +626,7 @@ cy.getByTestId('username-input').should('exist')
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-> In the spirit of [the guiding principles](#guiding-principles), it is
+> In the spirit of [the guiding principles](guiding-principles.md), it is
 > recommended to use this only after the other queries don't work for your use
 > case. Using data-testid attributes do not resemble how your software is used
 > and should be avoided if possible. That said, they are _way_ better than

--- a/docs/marko-testing-library/intro.md
+++ b/docs/marko-testing-library/intro.md
@@ -35,7 +35,7 @@ components. It provides light utility functions on top of
 in a way that encourages better testing practices. Its primary guiding principle
 is:
 
-> [The more your tests resemble the way your software is used, the more confidence they can give you.](#guiding-principles)
+> [The more your tests resemble the way your software is used, the more confidence they can give you.](guiding-principles.md)
 
 So rather than dealing with instances of rendered Marko components, your tests
 will work with actual DOM nodes. The utilities this library provides facilitate

--- a/docs/vue-testing-library/intro.md
+++ b/docs/vue-testing-library/intro.md
@@ -14,7 +14,7 @@ In short, Vue Testing Library does three things:
 
 1. Re-exports query utilities and helpers from `DOM Testing Library`.
 2. Hides `@vue/test-utils` methods that are in conflict with Testing Library
-   [Guiding Principle](/docs/guiding-principles).
+   [Guiding Principle](guiding-principles.md).
 3. Tweaks some methods from both sources.
 
 ## Quickstart


### PR DESCRIPTION
A couple of pages still refer to Guiding Principles as if they are sections on the same page.
* https://testing-library.com/docs/dom-testing-library/api-queries#bytestid
* https://testing-library.com/docs/marko-testing-library/intro

This PR fixes broken links and also tweaks one more link to make all paths to `guiding-principles.md` consistent. ✌️