### PR TITLE
Remove unnecessary whitespace in example-intro.md

### DIFF
--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -161,7 +161,7 @@ expect(getByTestId('ok-button')).toHaveAttribute('disabled')
 // snapshots work great with regular DOM nodes!
 expect(container).toMatchInlineSnapshot(`
   <div>
-    <button disabled >Ok</button>
+    <button disabled>Ok</button>
     <h1>hello there</h1>
   </div>
 `)


### PR DESCRIPTION
Replace `<button disabled >` with `<button disabled>`.