### PR TITLE
docs: update dom-testing-library/install.md to state react as library

### DIFF
--- a/docs/dom-testing-library/install.md
+++ b/docs/dom-testing-library/install.md
@@ -13,8 +13,8 @@ npm install --save-dev @testing-library/dom
 
 ## Wrappers
 
-If you are using a framework such as React, you will likely want to install the
-wrapper:
+If you are using a framework or library such as React, you will likely want to
+install the wrapper:
 
 - [React Testing Library](react-testing-library/intro.md)
 - [Cypress Testing Library](cypress-testing-library/intro.md)


### PR DESCRIPTION
Since react is a library not a framework, so it should be stated in the docs. Otherwise there is a chance of misconception.  