### PR TITLE
docs: pass options into render function

### DIFF
--- a/docs/react-testing-library/setup.md
+++ b/docs/react-testing-library/setup.md
@@ -157,7 +157,7 @@ import { render, queries, queryHelpers } from '@testing-library/react'
 import * as customQueries from './custom-queries'
 
 const customRender = (ui, options) =>
-  render(ui, { queries: { ...queries, ...customQueries } })
+  render(ui, { queries: { ...queries, ...customQueries }, ...options })
 
 // re-export everything
 export * from '@testing-library/react'


### PR DESCRIPTION
One of the customRender examples is accepting an options argument but not passing it to the rtl render function. This just adds it in.