### PR TITLE
docs(Angular): add examples and API

### DIFF
--- a/docs/angular-testing-library/api.md
+++ b/docs/angular-testing-library/api.md
@@ -1,0 +1,282 @@
+---
+id: api
+title: API
+sidebar_label: API
+---
+
+`Angular Testing Library` re-exports everything from `DOM Testing Library` as
+well as these methods:
+
+- [`render`](<(#render)>)
+
+## `render`
+
+```typescript
+function render<T>(
+  component: Type<T>,
+  renderOptions?: RenderOptions<T>
+): Promise<RenderResult>
+function render<T>(
+  template: string,
+  renderOptions: RenderOptions<T>
+): Promise<RenderResult>
+```
+
+## RenderOptions
+
+### `detectChanges`
+
+Will call `detectChanges` when the component is compiled
+
+**default** : `true`
+
+**example**:
+
+```typescript
+const component = await render(AppComponent, { detectChanges: false })
+```
+
+### `declarations`
+
+A collection of providers needed to render the component via Dependency
+Injection, for example, injectable services or tokens.
+
+For more info see the
+[Angular docs](https://angular.io/api/core/NgModule#providers).
+
+**default** : `[]`
+
+**example**:
+
+```typescript
+const component = await render(AppComponent, {
+  providers: [
+    CustomersService,
+    {
+      provide: MAX_CUSTOMERS_TOKEN,
+      useValue: 10,
+    },
+  ],
+})
+```
+
+### `imports`
+
+A collection of imports needed to render the component, for example, shared
+modules. Adds `NoopAnimationsModule` by default if `BrowserAnimationsModule`
+isn't added to the collection
+
+For more info see the
+[Angular docs](https://angular.io/api/core/NgModule#imports).
+
+**default** : `[NoopAnimationsModule]`
+
+**example**:
+
+```typescript
+const component = await render(AppComponent, {
+  imports: [AppSharedModule, MaterialModule],
+})
+```
+
+### `schemas`
+
+A collection of schemas needed to render the component. Allowed values are
+`NO_ERRORS_SCHEMA` and `CUSTOM_ELEMENTS_SCHEMA`.
+
+For more info see the
+[Angular docs](https://angular.io/api/core/NgModule#schemas).
+
+**default** : `[]`
+
+**example**:
+
+```typescript
+const component = await render(AppComponent, {
+  schemas: [NO_ERRORS_SCHEMA],
+})
+```
+
+### `componentProperties`
+
+An object to set `@Input` and `@Output` properties of the component.
+
+**default** : `{}`
+
+**example**:
+
+```typescript
+const component = await render(AppComponent, {
+  componentProperties: {
+    counterValue: 10,
+    send: (value) => { ... }
+  }
+})
+```
+
+### `componentProviders`
+
+A collection of providers to inject dependencies of the component.
+
+For more info see the
+[Angular docs](https://angular.io/api/core/Directive#providers).
+
+**default** : `[]`
+
+**example**:
+
+```typescript
+const component = await render(AppComponent, {
+  componentProviders: [AppComponentService],
+})
+```
+
+### `queries`
+
+Queries to bind. Overrides the default set from DOM Testing Library unless
+merged.
+
+**default** : `undefined`
+
+**example**:
+
+```typescript
+const component = await render(AppComponent, {
+  queries: { ...queries, ...customQueries },
+})
+```
+
+### `wrapper`
+
+An Angular component to wrap the component in.
+
+**default** : `WrapperComponent`, an empty component that strips the
+`ng-version` attribute.
+
+**example**:
+
+```typescript
+const component = await render(AppComponent, {
+  wrapper: CustomWrapperComponent,
+})
+```
+
+### `excludeComponentDeclaration`
+
+Exclude the component to be automatically be added as a declaration. This is
+needed when the component is declared in an imported module.
+
+**default** : `false`
+
+**example**:
+
+```typescript
+const component = await render(AppComponent, {
+  imports: [AppModule], // a module that includes AppComponent
+  excludeComponentDeclaration: true,
+})
+```
+
+## `RenderResult`
+
+### `...queries`
+
+The most important feature of `render` is that the queries from
+[DOM Testing Library](https://testing-library.com/docs/dom-testing-library) are
+automatically returned with their first argument bound to the component under
+test.
+
+See [Queries](https://testing-library.com/docs/dom-testing-library/api-queries)
+for a complete list.
+
+**example**:
+
+```typescript
+const component = await render(AppComponent)
+
+component.getByText('Hello world')
+component.queryByLabelText('First name:')
+```
+
+### `fireEvent.***`
+
+The second most important feature of `render` is that the events from
+[DOM Testing Library](https://testing-library.com/docs/dom-testing-library) are
+automatically bound to the Angular Component. This to ensure that the Angular
+change detection has been run by calling `detectChanges` after an event has been
+fired.
+
+See
+[Firing Events](https://testing-library.com/docs/dom-testing-library/api-events)
+for a complete list.
+
+**example**:
+
+```typescript
+const component = await render(AppComponent)
+
+component.change(component.getByLabelText('Username'), {
+  target: {
+    value: 'Tim',
+  },
+})
+component.click(component.getByText('Login'))
+```
+
+### `type`
+
+Types a value in an input field with the same interactions as the user would do.
+
+```typescript
+const component = await render(AppComponent)
+
+component.type(component.getByLabelText('Username'), 'Tim')
+component.type(component.getByLabelText('Username'), 'Tim', { delay: 250 })
+```
+
+### `selectOptions`
+
+Select an option(s) from a select field with the same interactions as the user
+would do.
+
+```typescript
+const component = await render(AppComponent)
+
+component.selectOptions(component.getByLabelText('Fruit'), 'Blueberry')
+component.selectOptions(component.getByLabelText('Fruit'), ['Blueberry'. 'Grape'])
+```
+
+### `fixture`
+
+The Angular `ComponentFixture` of the component.
+
+For more info see the
+[Angular docs](https://angular.io/api/core/testing/ComponentFixture).
+
+```typescript
+const component = await render(AppComponent)
+
+const componentInstance = component.fixture.componentInstance as AppComponent
+```
+
+> 🚨 If you find yourself using `fixture` to access the component's internal
+> values you should reconsider! This probable means, you're testing
+> implementation details.
+
+### `container`
+
+The containing DOM node of your rendered Angular Component. This is a regular
+DOM node, so you can call `container.querySelector` etc. to inspect the
+children.
+
+### `debug`
+
+Prints out the component's DOM with syntax highlighting. Accepts an optional
+parameter, to print out a specific DOM node.
+
+```typescript
+const component = await render(AppComponent)
+
+component.debug()
+component.debug(component.getByRole('alert'))
+```

--- a/docs/angular-testing-library/examples.md
+++ b/docs/angular-testing-library/examples.md
@@ -1,0 +1,69 @@
+---
+id: examples
+title: Examples
+sidebar_label: Examples
+---
+
+counter.component.ts
+
+```typescript
+@Component({
+  selector: 'counter',
+  template: `
+    <button (click)="decrement()">-</button>
+    <span data-testid="count">Current Count: {{ counter }}</span>
+    <button (click)="increment()">+</button>
+  `,
+})
+export class CounterComponent {
+  @Input() counter = 0
+
+  increment() {
+    this.counter += 1
+  }
+
+  decrement() {
+    this.counter -= 1
+  }
+}
+```
+
+counter.component.spec.ts
+
+```typescript
+import { render } from '@testing-library/angular'
+import CounterComponent from './counter.component.ts'
+
+describe('Counter', () => {
+  test('should render counter', async () => {
+    const { getByText } = await render(CounterComponent, {
+      componentProperties: { counter: 5 },
+    })
+
+    expect(getByText('Current Count: 5'))
+  })
+
+  test('should increment the counter on click', async () => {
+    const { getByText, click } = await render(CounterComponent, {
+      componentProperties: { counter: 5 },
+    })
+
+    click(getByText('+'))
+
+    expect(getByText('Current Count: 6'))
+  })
+})
+```
+
+More examples can be found in the
+[GitHub project](https://github.com/testing-library/angular-testing-library/tree/master/src/app/examples).
+These examples include:
+
+- `@Input` and `@Output` properties
+- (Reactive) Forms
+- Integration with NgRx (mock) Store
+- And more
+
+If you're looking for an example that isn't on the list, please feel free to
+create a
+[new issue](https://github.com/testing-library/angular-testing-library/issues/new).

--- a/docs/angular-testing-library/intro.md
+++ b/docs/angular-testing-library/intro.md
@@ -1,87 +1,57 @@
 ---
 id: intro
 title: Angular Testing Library
+sidebar_label: Introduction
 ---
 
-🦔 [`@testing-library/angular`][gh] Simple and complete
-[Angular](https://angular.io) testing utilities that encourage good testing
-practices.
+[`Angular Testing Library`](https://github.com/testing-library/angular-testing-library)
+builds on top of
+[`DOM Testing Library`](https://github.com/testing-library/dom-testing-library)
+by adding APIs for working with React components.
 
 ```bash
 npm install --save-dev @testing-library/angular
 ```
 
-- [`@testing-library/angular-testing-library` on GitHub][gh]
+- [`@testing-library/angular-testing-library` on GitHub](https://github.com/testing-library/angular-testing-library)
 
-## Usage
+## The problem
 
-counter.component.ts
+You want to write maintainable tests for your Angular components. As a part of
+this goal, you want your tests to avoid including implementation details of your
+components and rather focus on making your tests give you the confidence for
+which they are intended. As part of this, you want your testbase to be
+maintainable in the long run so refactors of your components (changes to
+implementation but not functionality) don't break your tests and slow you and
+your team down.
 
-```typescript
-@Component({
-  selector: 'counter',
-  template: `
-    <button (click)="decrement()">-</button>
-    <span data-testid="count">Current Count: {{ counter }}</span>
-    <button (click)="increment()">+</button>
-  `,
-})
-export class CounterComponent {
-  @Input() counter = 0
+## This solution
 
-  increment() {
-    this.counter += 1
-  }
+The `Angular Testing Library` is a very lightweight solution for testing Angular
+components. It provides light utility functions on top of
+[`DOM Testing Library`](https://github.com/testing-library/dom-testing-library)
+in a way that encourages better testing practices. Its primary guiding principle
+is:
 
-  decrement() {
-    this.counter -= 1
-  }
-}
-```
+> [The more your tests resemble the way your software is used, the more confidence they can give you.](guiding-principles.md)
 
-counter.component.spec.ts
+So rather than dealing with instances of rendered Angular components, your tests
+will work with actual DOM nodes. The utilities this library provides facilitate
+querying the DOM in the same way the user would. Finding for elements by their
+label text (just like a user would), finding links and buttons from their text
+(like a user would). It also exposes a recommended way to find elements by a
+`data-testid` as an "escape hatch" for elements where the text content and label
+do not make sense or is not practical.
 
-```typescript
-import { render } from '@testing-library/angular'
-import CounterComponent from './counter.component.ts'
+This library encourages your applications to be more accessible and allows you
+to get your tests closer to using your components the way a user will, which
+allows your tests to give you more confidence that your application will work
+when a real user uses it.
 
-describe('Counter', () => {
-  test('should render counter', async () => {
-    const { getByText } = await render(CounterComponent, {
-      componentProperties: { counter: 5 },
-    })
+The `Angular Testing Library`:
 
-    expect(getByText('Current Count: 5'))
-  })
-
-  test('should increment the counter on click', async () => {
-    const { getByText, click } = await render(CounterComponent, {
-      componentProperties: { counter: 5 },
-    })
-
-    click(getByText('+'))
-
-    expect(getByText('Current Count: 6'))
-  })
-})
-```
-
-## API
-
-There is a small difference between `@testing-library/angular` and the
-`testing-library` family, in this library we also expose all of the events via
-the `render` function. This is done to trigger Angular's change detection after
-each interaction.
-
-You can also import these event via `@testing-library/angular`, but the
-Angular's change detection will not be triggered automatically.
-
-The same counts for all the queries provided by the DOM Testing Library
-(`@testing-library/dom`), these are also re-exported and can be imported via
-`@testing-library/angular`.
-
-```typescript
-import { getByText, click } from '@testing-library/angular'
-```
-
-[gh]: https://github.com/testing-library/angular-testing-library
+- Re-exports the `query` and `fireEvent` utility functions from
+  [`DOM Testing Library`](https://github.com/testing-library/dom-testing-library).
+- Encapsulates the `fireEvent` functions of your component to automatically call
+  `detectChanges()` after an event occurs
+- Is test framework agnostic, it runs on every test framework

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -70,9 +70,18 @@
           "marko-testing-library/api"
         ]
       },
+      "angular-testing-library/intro",
+      {
+        "type": "subcategory",
+        "label": "Angular Testing Library",
+        "ids": [
+          "angular-testing-library/intro",
+          "angular-testing-library/examples",
+          "angular-testing-library/api"
+        ]
+      },
       "cypress-testing-library/intro",
       "svelte-testing-library/intro",
-      "angular-testing-library/intro",
       "pptr-testing-library/intro",
       "testcafe-testing-library/intro"
     ],


### PR DESCRIPTION
Adds documentation for Angular

- Wording on the introduction page to stay consistent with the other libraries
- API page
- Examples page - with reference to more examples in the angular repo