### PR TITLE
docs: use introduction in the side bar

### DIFF
--- a/docs/native-testing-library/intro.md
+++ b/docs/native-testing-library/intro.md
@@ -1,7 +1,7 @@
 ---
 id: intro
 title: Introduction
-sidebar_label: Intro
+sidebar_label: Introduction
 ---
 
 Native Testing Library is a testing library for **React Native** inspired by

--- a/docs/vue-testing-library/intro.md
+++ b/docs/vue-testing-library/intro.md
@@ -1,6 +1,7 @@
 ---
 id: intro
 title: Intro
+sidebar_label: Introduction
 ---
 
 Vue Testing Library builds on top of `DOM Testing Library` by adding APIs for


### PR DESCRIPTION
Most of the libraries use `Introduction` in the sidebar, this PR updates the ones that were using `Intro`.