### PR TITLE
Adds in missing parenthesis for an example

### DIFF
--- a/docs/guide-events.md
+++ b/docs/guide-events.md
@@ -63,7 +63,7 @@ getting blurred. To simulate this behavior you can simply replace `fireEvent`
 with imperative focus:
 
 ```diff
-- fireEvent.focus(getByText('focus me');
+- fireEvent.focus(getByText('focus me'));
 + getByText('focus me').focus();
 ```
 


### PR DESCRIPTION
Adds in missing parenthesis for `fireEvent.focus` example