### PR TITLE
docs(react-router): examples for react-router

### DIFF
--- a/docs/example-react-router.md
+++ b/docs/example-react-router.md
@@ -56,7 +56,7 @@ test('full app rendering/navigating', () => {
 })
 
 test('landing on a bad page shows 404 page', () => {
-  window.history.pushState({}, '', '/some/bad/route');
+  window.history.pushState({}, '', '/some/bad/route')
   const { getByRole } = render(
     <Router>
       <App />
@@ -67,7 +67,7 @@ test('landing on a bad page shows 404 page', () => {
 
 test('rendering a component that uses withRouter', () => {
   const route = '/some-route'
-  window.history.pushState({}, '', route);
+  window.history.pushState({}, '', route)
   const { getByTestId } = render(
     <Router>
       <LocationDisplay />
@@ -77,7 +77,7 @@ test('rendering a component that uses withRouter', () => {
 })
 ```
 
-### Reducing boilerplate
+## Reducing boilerplate
 
 If you find yourself adding Router components to your tests a lot, you may want to create
 a helper function that wraps around `render`. 

--- a/docs/example-react-router.md
+++ b/docs/example-react-router.md
@@ -79,7 +79,17 @@ test('rendering a component that uses withRouter', () => {
 
 ## Reducing boilerplate
 
-If you find yourself adding Router components to your tests a lot, you may want to create
+1. You can use the `wrapper` option to wrap `Router` around the component you want to render:
+
+```jsx
+test('full app rendering/navigating', () => {
+  const { container, getByText } = render(<App />, {wrapper: Router})
+  // verify page content for expected route
+  expect(getByRole('heading')).toMatch('Home')
+})
+```
+
+2. If you find yourself adding Router components to your tests a lot, you may want to create
 a helper function that wraps around `render`. 
 
 ```jsx

--- a/docs/example-react-router.md
+++ b/docs/example-react-router.md
@@ -4,6 +4,7 @@ title: React Router
 ---
 
 ```jsx
+// app.js
 import React from 'react'
 import { withRouter } from 'react-router'
 import { Link, Route, Router, Switch } from 'react-router-dom'
@@ -32,11 +33,57 @@ function App() {
     </div>
   )
 }
+```
 
-// Ok, so here's what your tests might look like
+```jsx
+// app.test.js
+import { Router } from 'react-router-dom'
 
-// this is a handy function that I would utilize for any component
-// that relies on the router being in context
+test('full app rendering/navigating', () => {
+  const { container, getByText } = render(
+    <Router>
+      <App />
+    </Router>
+  )
+  // verify page content for expected route
+  // often you'd use a data-testid or role query, but this is also possible
+  expect(container.innerHTML).toMatch('You are home')
+
+  fireEvent.click(getByText(/about/i))
+
+  // check that the content changed to the new page
+  expect(container.innerHTML).toMatch('You are on the about page')
+})
+
+test('landing on a bad page shows 404 page', () => {
+  window.history.pushState({}, '', '/some/bad/route');
+  const { getByRole } = render(
+    <Router>
+      <App />
+    </Router>
+  )
+  expect(getByRole('heading')).toHaveTextContent('404 Not Found')
+})
+
+test('rendering a component that uses withRouter', () => {
+  const route = '/some-route'
+  window.history.pushState({}, '', route);
+  const { getByTestId } = render(
+    <Router>
+      <LocationDisplay />
+    </Router>
+  )
+  expect(getByTestId('location-display').textContent).toBe(route)
+})
+```
+
+### Reducing boilerplate
+
+If you find yourself adding Router components to your tests a lot, you may want to create
+a helper function that wraps around `render`. 
+
+```jsx
+// test utils file
 function renderWithRouter(
   ui,
   {
@@ -52,22 +99,14 @@ function renderWithRouter(
     history,
   }
 }
+```
 
-test('full app rendering/navigating', () => {
-  const { container, getByText } = renderWithRouter(<App />)
-  // normally I'd use a data-testid, but just wanted to show this is also possible
-  expect(container.innerHTML).toMatch('You are home')
-  const leftClick = { button: 0 }
-  fireEvent.click(getByText(/about/i), leftClick)
-  // normally I'd use a data-testid, but just wanted to show this is also possible
-  expect(container.innerHTML).toMatch('You are on the about page')
-})
-
+```jsx
+// app.test.js
 test('landing on a bad page', () => {
   const { container } = renderWithRouter(<App />, {
     route: '/something-that-does-not-match',
   })
-  // normally I'd use a data-testid, but just wanted to show this is also possible
   expect(container.innerHTML).toMatch('No match')
 })
 
@@ -77,3 +116,4 @@ test('rendering a component that uses withRouter', () => {
   expect(getByTestId('location-display').textContent).toBe(route)
 })
 ```
+

--- a/docs/example-react-router.md
+++ b/docs/example-react-router.md
@@ -105,8 +105,9 @@ function renderWithRouter(
     history = createMemoryHistory({ initialEntries: [route] }),
   } = {}
 ) {
+  const Wrapper = ({children}) => <Router history={history}>{children}</Router>
   return {
-    ...render(<Router history={history}>{ui}</Router>),
+    ...render(ui, {wrapper: Wrapper}),
     // adding `history` to the returned utilities to allow us
     // to reference it in our tests (just try to avoid using
     // this to test implementation details).

--- a/docs/example-react-router.md
+++ b/docs/example-react-router.md
@@ -8,7 +8,6 @@ title: React Router
 import React from 'react'
 import { withRouter } from 'react-router'
 import { Link, Route, Router, Switch } from 'react-router-dom'
-import { createMemoryHistory } from 'history'
 import { render, fireEvent } from '@testing-library/react'
 
 const About = () => <div>You are on the about page</div>
@@ -38,10 +37,12 @@ function App() {
 ```jsx
 // app.test.js
 import { Router } from 'react-router-dom'
+import { createMemoryHistory } from 'history'
 
 test('full app rendering/navigating', () => {
+  const history = createMemoryHistory()
   const { container, getByText } = render(
-    <Router>
+    <Router history={history}>
       <App />
     </Router>
   )
@@ -56,7 +57,8 @@ test('full app rendering/navigating', () => {
 })
 
 test('landing on a bad page shows 404 page', () => {
-  window.history.pushState({}, '', '/some/bad/route')
+  const history = createMemoryHistory()
+  history.push('/some/bad/route')
   const { getByRole } = render(
     <Router>
       <App />
@@ -79,11 +81,13 @@ test('rendering a component that uses withRouter', () => {
 
 ## Reducing boilerplate
 
-1. You can use the `wrapper` option to wrap `Router` around the component you want to render:
+1. You can use the `wrapper` option to wrap a `MemoryRouter` around the component you want to render (`MemoryRouter` works when you don't need access to the history object itself in the test, but just need the components to be able to render and navigate).
 
 ```jsx
+import { MemoryRouter } from 'react-router-dom'
+
 test('full app rendering/navigating', () => {
-  const { container, getByText } = render(<App />, {wrapper: Router})
+  const { container, getByText } = render(<App />, {wrapper: MemoryRouter})
   // verify page content for expected route
   expect(getByRole('heading')).toMatch('Home')
 })


### PR DESCRIPTION
- extract out "renderWithRouter" helper and explain when it is needed
- add some "getBy" queries instead of just container.innerHTML assertions, to show more idiomatic RTL usage