### PR TITLE
Update events doc for event.which usage on keyboard events

### DIFF
--- a/docs/dom-testing-library/api-events.md
+++ b/docs/dom-testing-library/api-events.md
@@ -70,6 +70,10 @@ fireEvent.keyDown(domNode, { key: 'Enter', code: 13 })
 // will Fire an KeyboardEvent with charCode = 0
 fireEvent.keyDown(domNode, { key: 'Enter', code: 13 })
 
+// If using event.which, be sure to set the keyCode or it will be fallback to 0
+// will Fire a KeyboardEvent with expected which = 13
+fireEvent.keyDown(domNode, { key: 'Enter', keyCode: 13 })
+
 // will Fire an KeyboardEvent with charCode = 65
 fireEvent.keyDown(domNode, { key: 'A', code: 65, charCode: 65 })
 ```


### PR DESCRIPTION
When using `fireEvent.keyDown` the `event.which` value is a fallback of `0` unless the `keyCode` is passed. I thought this might be helpful for other folks trying the same.

e.g.

```js
fireEvent.keyDown(domNode, { key: 'Enter', code: 13, charCode: 13 }); // event.which => 0

fireEvent.keyDown(domNode, { key: 'Enter', keyCode: 13 }); // event.which => 13
```