### PR TITLE
Add note about component instance and methods to main FAQ

### DIFF
--- a/docs/dom-testing-library/faq.md
+++ b/docs/dom-testing-library/faq.md
@@ -94,6 +94,23 @@ const thirdItem = getByTestId(container, `item-${items[2].id}`)
 
 </details>
 
+<details>
+<summary>
+  Help! I can't access component methods or the component instance!
+</summary>
+
+This is **intentional**.
+
+We want you to focus on testing the output and functionality of the component as
+it is observed by the user and to **avoid worrying about the implementation
+details** of the component.
+
+We believe this leads to less brittle and more meaningful test code.
+
+Please refer to the [Guiding Principles](../guiding-principles) of this testing
+library for more info.
+
+</details>
 <!--
 Links:
 -->


### PR DESCRIPTION
I added a note to the main FAQ about accessing the component instance and redirect the user to the guiding-principles of the library.

This is in reference to this tweet from Kent: https://twitter.com/kentcdodds/status/1179390041031892995