### PR TITLE
docs: add aria-query doc link to ByRole query

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -543,7 +543,10 @@ Queries for elements with the given role (and it also accepts a
 `<button />` has the `button` role without explicitly setting the `role`
 attribute. The
 [W3C HTML recommendation](https://www.w3.org/TR/html5/index.html#contents) lists
-all HTML elements with their default aria roles.
+all HTML elements with their default aria roles. Additionally, as DOM Testing
+Library uses `aria-query` under the hood to find those elements by their default
+aria roles, you can find in their docs
+[which HTML Elements with inherent roles are mapped to each role](https://github.com/A11yance/aria-query#elements-to-roles).
 
 If you set `hidden` to `true` elements that are normally excluded from the
 accessibility tree are considered for the query as well. The default behavior

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -543,9 +543,9 @@ Queries for elements with the given role (and it also accepts a
 `<button />` has the `button` role without explicitly setting the `role`
 attribute. The
 [W3C HTML recommendation](https://www.w3.org/TR/html5/index.html#contents) lists
-all HTML elements with their default aria roles. Additionally, as DOM Testing
+all HTML elements with their default ARIA roles. Additionally, as DOM Testing
 Library uses `aria-query` under the hood to find those elements by their default
-aria roles, you can find in their docs
+ARIA roles, you can find in their docs
 [which HTML Elements with inherent roles are mapped to each role](https://github.com/A11yance/aria-query#elements-to-roles).
 
 If you set `hidden` to `true` elements that are normally excluded from the


### PR DESCRIPTION
I find quite handy the [list of HTML elements mapped to roles from aria-query](https://github.com/A11yance/aria-query#elements-to-roles) and I usually go there for finding available roles for HTML Elements, so I think it would be a nice addition to have proper reference to that documentation within `ByRole` doc (apart from the fact that DOM Testing Library uses aria-query)