### PR TITLE
removed the example for getting by label

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -87,12 +87,6 @@ The example below will find the input node for the following DOM structures:
 <label id="username-label">Username</label>
 <input aria-labelledby="username-label" />
 
-// The aria-labelledby attribute with non-form elements
-<section aria-labelledby="section-one-header">
-  <h3 id="section-one-header">Section One</h3>
-  <p>some content</p>
-</section>
-
 // Wrapper labels
 <label>Username <input /></label>
 


### PR DESCRIPTION
for a non input html because the javascript example does not use it.

Closes #236