### PR TITLE
Update cypress configure documentation

### DIFF
--- a/docs/dom-testing-library/api-configuration.md
+++ b/docs/dom-testing-library/api-configuration.md
@@ -41,7 +41,10 @@ configure({testIdAttribute: 'my-data-test-id'})`
 <!--Cypress-->
 
 ```
-The configuration object is not currently exposed to in Cypress Testing Library
+// setup-tests.js
+import { configure } from '@testing-library/cypress'
+
+configure({testIdAttribute: 'my-data-test-id'})`
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
`configure` is exported from `@testing-library/cypress` as of https://github.com/testing-library/cypress-testing-library/pull/81 / version 4.2.0

Update documentation to describe `configure` usage with cypress.