### PR TITLE
Fix user-event example

### DIFF
--- a/docs/ecosystem-user-event.md
+++ b/docs/ecosystem-user-event.md
@@ -16,12 +16,12 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-const { getByText } = test('click', () => {
-  render(<textarea data-testid="email" />)
-})
+test('Fill text area', () => {
+  const { getByTestId } = render(<textarea data-testid="email" />)
 
-userEvent.type(getByTestId('email'), 'Hello, World!')
-expect(getByTestId('email')).toHaveAttribute('value', 'Hello, World!')
+  userEvent.type(getByTestId('email'), 'Hello, World!')
+  expect(getByTestId('email')).toHaveAttribute('value', 'Hello, World!')
+})
 ```
 
 - [user-event on GitHub][gh]


### PR DESCRIPTION
The example code was destructuring `getByText` instead of `getByTestId` which is what is used later. Also, moved `test` to wrap the code right and changed it's name.