### PR TITLE
docs: Prefer byRole over byTestId where possible

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -620,7 +620,7 @@ A shortcut to `` container.querySelector(`[data-testid="${yourId}"]`) `` (and it
 also accepts a [`TextMatch`](#textmatch)).
 
 ```html
-<input data-testid="username-input" />
+<div data-testid="custom-element" />
 ```
 
 <!--DOCUSAURUS_CODE_TABS-->
@@ -631,7 +631,7 @@ also accepts a [`TextMatch`](#textmatch)).
 import { getByTestId } from '@testing-library/dom'
 
 const container = document.body
-const usernameInput = getByTestId(container, 'username-input')
+const element = getByTestId(container, 'custom-element')
 ```
 
 <!--React-->
@@ -640,13 +640,13 @@ const usernameInput = getByTestId(container, 'username-input')
 import { render } from '@testing-library/react'
 
 const { getByTestId } = render(<MyComponent />)
-const usernameInput = getByTestId('username-input')
+const element = getByTestId('custom-element')
 ```
 
 <!--Cypress-->
 
 ```js
-cy.getByTestId('username-input').should('exist')
+cy.getByTestId('custom-element').should('exist')
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -486,7 +486,7 @@ In case of `select`, this will search for a `<select>` whose selected `<option>`
 matches the given [`TextMatch`](#textmatch).
 
 ```html
-<select id="state-select" data-testid="state">
+<select>
   <option value="">State</option>
   <option value="AL">Alabama</option>
   <option selected value="AK">Alaska</option>

--- a/docs/dom-testing-library/faq.md
+++ b/docs/dom-testing-library/faq.md
@@ -76,20 +76,20 @@ in the selector.
 const thirdLiInUl = container.querySelector('ul > li:nth-child(3)')
 ```
 
-Or you could include the index or an ID in your attribute:
+Or you could query the `listitem` role and access the index in question:
 
 ```javascript
-;`<li data-testid="item-${item.id}">{item.text}</li>`
+;`<li>{item.text}</li>`
 ```
 
-And then you could use the `getByTestId` utility:
+And then you could use the `getAllByRole` utility:
 
 ```javascript
 const items = [
   /* your items */
 ]
 const container = render(/* however you render this stuff */)
-const thirdItem = getByTestId(container, `item-${items[2].id}`)
+const thirdItem = getAllByRole(container, 'listitem')[2]
 ```
 
 </details>

--- a/docs/dom-testing-library/faq.md
+++ b/docs/dom-testing-library/faq.md
@@ -76,13 +76,8 @@ in the selector.
 const thirdLiInUl = container.querySelector('ul > li:nth-child(3)')
 ```
 
-Or you could query the `listitem` role and access the index in question:
-
-```javascript
-;`<li>{item.text}</li>`
-```
-
-And then you could use the `getAllByRole` utility:
+Or you could use `getAllByRole` to query the `listitem` role and access the
+index in question:
 
 ```javascript
 const items = [

--- a/docs/ecosystem-user-event.md
+++ b/docs/ecosystem-user-event.md
@@ -16,12 +16,12 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-test('Fill text area', () => {
-  const { getByTestId } = render(<textarea data-testid="email" />)
-
-  userEvent.type(getByTestId('email'), 'Hello, World!')
-  expect(getByTestId('email')).toHaveAttribute('value', 'Hello, World!')
+const { getByRole } = test('click', () => {
+  render(<textarea />)
 })
+
+userEvent.type(getByRole('textbox'), 'Hello, World!')
+expect(getByRole('textbox')).toHaveAttribute('value', 'Hello, World!')
 ```
 
 - [user-event on GitHub][gh]

--- a/docs/ecosystem-user-event.md
+++ b/docs/ecosystem-user-event.md
@@ -16,12 +16,12 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-const { getByRole } = test('click', () => {
-  render(<textarea />)
-})
+test('click', () => {
+  const { getByRole } = render(<textarea />)
 
-userEvent.type(getByRole('textbox'), 'Hello, World!')
-expect(getByRole('textbox')).toHaveAttribute('value', 'Hello, World!')
+  userEvent.type(getByRole('textbox'), 'Hello, World!')
+  expect(getByRole('textbox')).toHaveAttribute('value', 'Hello, World!')
+})
 ```
 
 - [user-event on GitHub][gh]

--- a/docs/guide-which-query.md
+++ b/docs/guide-which-query.md
@@ -33,8 +33,8 @@ possible. With this in mind, we recommend this order of priority:
       difficult-to-capture elements in a more semantic way
 1. **Test IDs**
    1. `getByTestId`: The user cannot see (or hear) these, so this is only
-      recommended for cases where you can't match by text or it doesn't make
-      sense (the text is dynamic).
+      recommended for cases where you can't match by role or text or it doesn't
+      make sense (e.g. the text is dynamic).
 
 ## Manual Queries
 

--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -11,18 +11,14 @@ See the following sections for a detailed breakdown of the test
 ```jsx
 // __tests__/fetch.test.js
 import React from 'react'
-import {
-  render,
-  fireEvent,
-  waitForElement,
-} from '@testing-library/react'
+import { render, fireEvent, waitForElement } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import axiosMock from 'axios'
 import Fetch from '../fetch'
 
 test('loads and displays greeting', async () => {
   const url = '/greeting'
-  const { getByText, getByTestId } = render(<Fetch url={url} />)
+  const { getByText, getByRole } = render(<Fetch url={url} />)
 
   axiosMock.get.mockResolvedValueOnce({
     data: { greeting: 'hello there' },
@@ -30,14 +26,12 @@ test('loads and displays greeting', async () => {
 
   fireEvent.click(getByText('Load Greeting'))
 
-  const greetingTextNode = await waitForElement(() =>
-    getByTestId('greeting-text')
-  )
+  const greetingTextNode = await waitForElement(() => getByRole('heading'))
 
   expect(axiosMock.get).toHaveBeenCalledTimes(1)
   expect(axiosMock.get).toHaveBeenCalledWith(url)
-  expect(getByTestId('greeting-text')).toHaveTextContent('hello there')
-  expect(getByTestId('ok-button')).toHaveAttribute('disabled')
+  expect(getByRole('heading')).toHaveTextContent('hello there')
+  expect(getByRole('button')).toHaveAttribute('disabled')
 })
 ```
 
@@ -52,11 +46,7 @@ test('loads and displays greeting', async () => {
 import React from 'react'
 
 // import react-testing methods
-import {
-  render,
-  fireEvent,
-  waitForElement,
-} from '@testing-library/react'
+import { render, fireEvent, waitForElement } from '@testing-library/react'
 
 // add custom jest matchers from jest-dom
 import '@testing-library/jest-dom/extend-expect'
@@ -84,7 +74,7 @@ returns utility functions for testing the component.
 
 ```jsx
 const url = '/greeting'
-const { getByText, getByTestId, container, asFragment } = render(
+const { getByText, getByRole, container, asFragment } = render(
   <Fetch url={url} />
 )
 ```
@@ -106,8 +96,8 @@ fireEvent.click(getByText('Load Greeting'))
 // `waitForElement` waits until the callback doesn't throw an error
 
 const greetingTextNode = await waitForElement(() =>
-  // getByTestId throws an error if it cannot find an element
-  getByTestId('greeting-text')
+  // getByRole throws an error if it cannot find an element
+  getByRole('heading')
 )
 ```
 
@@ -116,56 +106,50 @@ const greetingTextNode = await waitForElement(() =>
 fetch.js
 
 ```jsx
-import React,{useState} from 'react'
+import React, { useState } from 'react'
 import axios from 'axios'
 
-export default function Fetch({url}) {
+export default function Fetch({ url }) {
   const [greeting, setGreeting] = useState('')
   const [buttonClicked, setButtonClicked] = useState(false)
-  
+
   const fetchGreeting = async () => {
     const response = await axios.get(url)
     const data = response.data
-    const {greeting} = data
+    const { greeting } = data
     setGreeting(greeting)
     setButtonClicked(true)
   }
 
   const buttonText = buttonClicked ? 'Ok' : 'Load Greeting'
-  
+
   return (
     <div>
-      <button 
-        onClick={fetchGreeting} 
-        data-testid ='ok-button' 
-        disabled={buttonClicked}>
-          {buttonText}
+      <button onClick={fetchGreeting} disabled={buttonClicked}>
+        {buttonText}
       </button>
-      {greeting ? <h1 data-testid ='greeting-text'>{greeting}</h1> : null}
+      {greeting ? <h1>{greeting}</h1> : null}
     </div>
-    )
+  )
 }
 ```
 
 ```jsx
 expect(axiosMock.get).toHaveBeenCalledTimes(1)
 expect(axiosMock.get).toHaveBeenCalledWith(url)
-expect(getByTestId('greeting-text')).toHaveTextContent('hello there')
-expect(getByTestId('ok-button')).toHaveAttribute('disabled')
+expect(getByRole('heading')).toHaveTextContent('hello there')
+expect(getByRole('button')).toHaveAttribute('disabled')
 
 // snapshots work great with regular DOM nodes!
 expect(container).toMatchInlineSnapshot(`
   <div>
     <div>
       <button
-        data-testid="ok-button"
         disabled=""
       >
         Ok
       </button>
-      <h1
-        data-testid="greeting-text"
-      >
+      <h1>
         hello there
       </h1>
     </div>

--- a/docs/vue-testing-library/cheatsheet.md
+++ b/docs/vue-testing-library/cheatsheet.md
@@ -36,7 +36,7 @@ A short guide to all the exported functions in `Vue Testing Library`.
 | **...ByAltText**         | img alt attribute                | `<img alt="movie poster" />`          |
 | **...ByTitle**           | title attribute or svg title tag | `<span title="Add" />` or `<title />` |
 | **...ByRole**            | ARIA role                        | `<div role="dialog" />`               |
-| **...ByTestId**          | data-testid attribute            | `<input data-testid="input" />`       |
+| **...ByTestId**          | data-testid attribute            | `<div data-testid="some-message" />`  |
 
 > You can write any combination of Search variants and Search types.
 


### PR DESCRIPTION
This is a collection of changes that tries to reduce the amount of `byTestId` usages.

`byTestId` is especially problematic for component libraries since the markup is very often not simple (e.g. includes wrapper divs) and users often ask where they should put the testId or claim the library in question is not very well testable with `@testing-library/*`. 

In many cases a `byRole` query would have resolved those questions.

It is probably a good idea to also add a table to the docs explaining which HTML elements map to which ARIA role. I'd like to to do this in a separate PR since there are some unresolved issues with `aria-query` and we need to figure out where the source of truth is (aria-query or html-aam).