### PR TITLE
fix: typos in debugging example

### DIFF
--- a/docs/dom-testing-library/api-helpers.md
+++ b/docs/dom-testing-library/api-helpers.md
@@ -217,7 +217,7 @@ Unable to find an element with the text: Goodbye world. This could be because th
 Here is the state of your container:
 <div>
   <div>
-    Hello World!
+    Hello world
   </div>
 </div>
 ```
@@ -232,7 +232,7 @@ Here's how you might increase this limit when running tests:
 DEBUG_PRINT_LIMIT=10000 npm test
 ```
 
-This works on macOS/linux, you'll need to do something else for windows. If
+This works on macOS/Linux, you'll need to do something else for Windows. If
 you'd like a solution that works for both, see
 [`cross-env`](https://www.npmjs.com/package/cross-env)
 


### PR DESCRIPTION
I found a typo in the example output under the [Debugging section](https://testing-library.com/docs/dom-testing-library/api-helpers#debugging).

Given our element is
```html
<div>Hello world</div>
```

The `container` output should be
```html
<div>
  <div>
    Hello world
  </div>
</div>
```

instead of
```html
<div>
  <div>
    Hello World!
  </div>
</div>
```
---
The PR also fixes some small capitalization errors.