### PR TITLE
Remove cleanup() references from Vue docs

### DIFF
--- a/docs/vue-testing-library/api.md
+++ b/docs/vue-testing-library/api.md
@@ -25,6 +25,7 @@ It also exposes these methods:
 - [`fireEvent`](#fireevent)
   - [`touch(elem)`](#touchelem)
   - [`update(elem, value)`](#updateelem-value)
+- [`cleanup`](#cleanup)
 
 ---
 
@@ -199,3 +200,17 @@ input/select/textarea inner value while emitting the appropiate native event.
 
 See a working example of `update` in the
 [v-model example test](/docs/vue-testing-library/examples#example-using-v-model).
+
+---
+
+## `cleanup`
+
+Unmounts Vue trees that were mounted with [render](#render).
+
+> If you are using an environment that supports `afterEach` hook (as in Jest),
+> there's no need to call `cleanup` manually. Vue Testing Library handles it for
+> you.
+
+Failing to call `cleanup` when you've called `render` could result in a memory
+leak and tests which are not idempotent (which can lead to difficult to debug
+errors in your tests).

--- a/docs/vue-testing-library/api.md
+++ b/docs/vue-testing-library/api.md
@@ -25,7 +25,6 @@ It also exposes these methods:
 - [`fireEvent`](#fireevent)
   - [`touch(elem)`](#touchelem)
   - [`update(elem, value)`](#updateelem-value)
-- [`cleanup`](#cleanup)
 
 ---
 
@@ -200,32 +199,3 @@ input/select/textarea inner value while emitting the appropiate native event.
 
 See a working example of `update` in the
 [v-model example test](/docs/vue-testing-library/examples#example-using-v-model).
-
----
-
-## `cleanup`
-
-Unmounts Vue trees that were mounted with [render](#render).
-
-```jsx
-import { cleanup, render } from '@testing-library/vue'
-import Component from './Component.vue'
-
-afterEach(cleanup) // <-- add this
-
-test('renders into document', () => {
-  render(Component)
-  // ...
-})
-
-// ... more tests ...
-```
-
-Failing to call `cleanup` when you've called `render` could result in a memory
-leak and tests which are not "idempotent" (which can lead to difficult to debug
-errors in your tests).
-
-**If you don't want to add this to _every single test file_** then we recommend
-that you configure your test framework to run a file before your tests which
-does this automatically. See the [setup](./setup) section for guidance on how to
-set up your framework.

--- a/docs/vue-testing-library/cheatsheet.md
+++ b/docs/vue-testing-library/cheatsheet.md
@@ -89,8 +89,6 @@ For more information, see [Events API](dom-testing-library/api-events.md)
   to it: `within(getByTestId("global-header")).getByText("hello")`.
 - **configure(config)** change global options:
   `configure({testIdAttribute: 'my-test-id'})`.
-- **cleanup()** clears the DOM ([use with `afterEach`](setup.md#cleanup) to
-  reset DOM between tests).
 
 For more information, see [Helpers API](dom-testing-library/api-helpers.md) and
 [Config API](dom-testing-library/api-configuration.md).

--- a/docs/vue-testing-library/examples.md
+++ b/docs/vue-testing-library/examples.md
@@ -29,11 +29,8 @@ title: Examples
 ```
 
 ```js
-import { render, fireEvent, cleanup } from '@testing-library/vue'
+import { render, fireEvent } from '@testing-library/vue'
 import Component from './Component.vue'
-
-// automatically unmount and cleanup DOM after the test is finished.
-afterEach(cleanup)
 
 test('increments value on click', async () => {
   // The render method returns a collection of utilities to query your component.
@@ -75,10 +72,8 @@ test('increments value on click', async () => {
 ```
 
 ```js
-import { render, fireEvent, cleanup } from '@testing-library/vue'
+import { render, fireEvent } from '@testing-library/vue'
 import Component from './Component.vue'
-
-afterEach(cleanup)
 
 test('properly handles v-model', async () => {
   const { getByLabelText, getByText } = render(Component)


### PR DESCRIPTION
`cleanup()` is automatically run `afterEach` hook, so there's no need to suggest adding it by default.