### PR TITLE
Clarify testIdAttribute

### DIFF
--- a/docs/dom-testing-library/api-configuration.md
+++ b/docs/dom-testing-library/api-configuration.md
@@ -29,7 +29,7 @@ and related queries. Defaults to `data-testid`.
 // setup-tests.js
 import { configure } from '@testing-library/dom'
 
-configure({testIdAttribute: 'my-data-test-id'})
+configure({testIdAttribute: 'data-my-test-id'})
 ```
 
 <!--React-->
@@ -38,7 +38,7 @@ configure({testIdAttribute: 'my-data-test-id'})
 // setup-tests.js
 import { configure } from '@testing-library/react'
 
-configure({testIdAttribute: 'my-data-test-id'})
+configure({testIdAttribute: 'data-my-test-id'})
 ```
 
 <!--Cypress-->
@@ -47,7 +47,7 @@ configure({testIdAttribute: 'my-data-test-id'})
 // setup-tests.js
 import { configure } from '@testing-library/cypress'
 
-configure({testIdAttribute: 'my-data-test-id'})
+configure({testIdAttribute: 'data-my-test-id'})
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
I was a bit confused while reading through these docs as to whether or not the value I supplied to `testIdAttribute` would be prefixed with `data-`. It turns out that the value is _not_ prefixed, and so `my-data-test-id` wouldn't be a valid `data-` attribute. This change replaces the current example `my-data-test-id` with `data-my-test-id`. I think this makes this example more clear.