### PR TITLE
add jest.mock() instruction

### DIFF
--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -52,14 +52,12 @@ import { render, fireEvent, waitForElement } from '@testing-library/react'
 
 // add custom jest matchers from jest-dom
 import '@testing-library/jest-dom/extend-expect'
-
-// the axios mock is in __mocks__/
-// see https://jestjs.io/docs/en/manual-mocks
 import axiosMock from 'axios'
-jest.mock('axios')
-
 // the component to test
 import Fetch from '../fetch'
+
+// https://jestjs.io/docs/en/mock-functions#mocking-modules
+jest.mock('axios')
 ```
 
 ```jsx

--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -16,6 +16,8 @@ import '@testing-library/jest-dom/extend-expect'
 import axiosMock from 'axios'
 import Fetch from '../fetch'
 
+jest.mock('axios')
+
 test('loads and displays greeting', async () => {
   const url = '/greeting'
   const { getByText, getByRole } = render(<Fetch url={url} />)
@@ -54,6 +56,7 @@ import '@testing-library/jest-dom/extend-expect'
 // the axios mock is in __mocks__/
 // see https://jestjs.io/docs/en/manual-mocks
 import axiosMock from 'axios'
+jest.mock('axios')
 
 // the component to test
 import Fetch from '../fetch'


### PR DESCRIPTION
This code does not work without specifically instructing the manual mock.
It is only the case while automock is set to false (as it is by default, and create-react-app does not support overriding it)