### PR TITLE
Fix component name: from App to Modal

### DIFF
--- a/docs/example-react-modal.md
+++ b/docs/example-react-modal.md
@@ -12,7 +12,7 @@ const modalRoot = document.createElement('div')
 modalRoot.setAttribute('id', 'modal-root')
 document.body.appendChild(modalRoot)
 
-const App = ({ onClose, children }) => {
+const Modal = ({ onClose, children }) => {
   const el = document.createElement('div')
 
   useEffect(() => {


### PR DESCRIPTION
This PR changes the example such that the component has the name that is referenced in the test.