### PR TITLE
Update Cypress intro.md

### DIFF
--- a/docs/cypress-testing-library/intro.md
+++ b/docs/cypress-testing-library/intro.md
@@ -24,7 +24,7 @@ import '@testing-library/cypress/add-commands';
 
 You can now use all of `DOM Testing Library`'s `findBy`, `findAllBy`, `queryBy`
 and `queryAllBy` commands off the global `cy` object.
-[See the `DOM Testing Library` docs for reference](https://testing-library.com).
+[See the `DOM Testing Library` docs for reference](https://testing-library.com/docs/dom-testing-library/api-queries).
 
 > Note: the `get*` queries are not supported because for reasonable Cypress tests you
 > need retryability and `find*` queries already support that. The reason the `query*`


### PR DESCRIPTION
Currently, the hyperlink attached to `See the DOM Testing Library docs for reference` takes you to `testing-library`'s home page (`testing-library.com`). It makes more sense (for the given text) to link to the DOM Testing Library API docs, in my opinion.