### PR TITLE
feat(byRole): Add `name` option

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -164,8 +164,11 @@ cy.getByLabelText('username').should('exist')
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-It will NOT find the input node for label text broken up by elements. If it is
-important that you query an actual `<label>` element you can provide a
+It will NOT find the input node for label text broken up by elements. You can
+use `getByRole('textbox', { name: 'Username' })` instead which is robust against
+switching to `aria-label` or `aria-labelledby`.
+
+If it is important that you query an actual `<label>` element you can provide a
 `selector` in the options:
 
 ```html
@@ -178,9 +181,6 @@ const inputNode = getByLabelText(container, 'Username', {
   selector: 'input',
 })
 ```
-
-Otherwise `byRole('textbox', { name: 'Username' })` works as well and is robust
-against switching to `aria-label` or `aria-labelledby`.
 
 ### `ByPlaceholderText`
 
@@ -594,12 +594,12 @@ a specific element if multiple elements with the same role are present on the
 rendered content. For an in-depth guide check out
 ["What is an accessible name?" from ThePacielloGroup](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/).
 If you only query for a single element with `getByText('The name')` it's
-oftentimes better to use `byRole(expectedRole, { name: 'The name' })`. The
+oftentimes better to use `getByRole(expectedRole, { name: 'The name' })`. The
 accessible name query does not replace other queries such as `byAlt` or
 `byTitle`. While the accessible name can be equal to these attributes, it does
 not replace the functionality of these attributes. For example
 `<img aria-label="fancy image" src="fancy.jpg" />` will be returned for both
-`getByAlt('fancy image')` and `byRole('image', { name: 'fancy image' })`.
+`getByAlt('fancy image')` and `getByRole('image', { name: 'fancy image' })`.
 However, the image will not display its description if `fancy.jpg` could not be
 loaded. Whether you want assert this functionality in your test or not is up to
 you.

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -164,8 +164,9 @@ cy.getByLabelText('username').should('exist')
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-It will NOT find the input node for label text broken up by elements. For this
-case, you can provide a `selector` in the options:
+It will NOT find the input node for label text broken up by elements. If it is
+important that you query an actual `<label>` element you can provide a
+`selector` in the options:
 
 ```html
 <label> <span>Username</span> <input /> </label>
@@ -177,6 +178,9 @@ const inputNode = getByLabelText(container, 'Username', {
   selector: 'input',
 })
 ```
+
+Otherwise `byRole('textbox', { name: 'Username' })` works as well and is robust
+against switching to `aria-label` or `aria-labelledby`.
 
 ### `ByPlaceholderText`
 
@@ -567,6 +571,7 @@ getByRole(
   options?: {
     exact?: boolean = true,
     hidden?: boolean = true,
+    name?: TextMatch,
     normalizer?: NormalizerFn,
   }): HTMLElement
 ```
@@ -580,6 +585,24 @@ all HTML elements with their default ARIA roles. Additionally, as DOM Testing
 Library uses `aria-query` under the hood to find those elements by their default
 ARIA roles, you can find in their docs
 [which HTML Elements with inherent roles are mapped to each role](https://github.com/A11yance/aria-query#elements-to-roles).
+
+You can query the returned element(s) by their
+[accessible name](https://www.w3.org/TR/accname-1.1/). The accessible name is
+for simple cases equal to e.g. the label of a form element, or the text content
+of a button, or the value of the `aria-label` attribute. It can be used to query
+a specific element if multiple elements with the same role are present on the
+rendered content. For an in-depth guide check out
+["What is an accessible name?" from ThePacielloGroup](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/).
+If you only query for a single element with `getByText('The name')` it's
+oftentimes better to use `byRole(expectedRole, { name: 'The name' })`. The
+accessible name query does not replace other queries such as `byAlt` or
+`byTitle`. While the accessible name can be equal to these attributes, it does
+not replace the functionality of these attributes. For example
+`<img aria-label="fancy image" src="fancy.jpg" />` will be returned for both
+`getByAlt('fancy image')` and `byRole('image', { name: 'fancy image' })`.
+However, the image will not display its description if `fancy.jpg` could not be
+loaded. Whether you want assert this functionality in your test or not is up to
+you.
 
 If you set `hidden` to `true` elements that are normally excluded from the
 accessibility tree are considered for the query as well. The default behavior

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -595,8 +595,8 @@ rendered content. For an in-depth guide check out
 ["What is an accessible name?" from ThePacielloGroup](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/).
 If you only query for a single element with `getByText('The name')` it's
 oftentimes better to use `getByRole(expectedRole, { name: 'The name' })`. The
-accessible name query does not replace other queries such as `byAlt` or
-`byTitle`. While the accessible name can be equal to these attributes, it does
+accessible name query does not replace other queries such as `*ByAlt` or
+`*ByTitle`. While the accessible name can be equal to these attributes, it does
 not replace the functionality of these attributes. For example
 `<img aria-label="fancy image" src="fancy.jpg" />` will be returned for both
 `getByAlt('fancy image')` and `getByRole('image', { name: 'fancy image' })`.

--- a/docs/guide-which-query.md
+++ b/docs/guide-which-query.md
@@ -14,17 +14,17 @@ possible. With this in mind, we recommend this order of priority:
    1. `getByLabelText`: Only really good for form fields, but this is the number
       one method a user finds those elements, so it should be your top
       preference.
-   1. `getByRole`: With the `name` option you can basically query the full
-      accessibility tree. It can query all the elements you can query with the
-      other accessility query. But consider that you still might want to assert
-      if an element has an actual `<label>` element or a `placeholder`
-      attribute.
    1. `getByPlaceholderText`:
       [A placeholder is not a substitute for a label](https://www.nngroup.com/articles/form-design-placeholders/).
       But if that's all you have, then it's better than alternatives.
+   1. `getByRole`: This can be used to query every element that is exposed in
+      the
+      [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/AOM).
+      With the `name` option you can filter the returned elements by their
+      [accessible name](https://www.w3.org/TR/accname-1.1/). This should be your
+      top preference for interactive elements such as buttons.
    1. `getByText`: Not useful for forms, but this is the number 1 method a user
-      finds other elements (like buttons to click), so it should be your top
-      preference for non-form elements.
+      finds most non-interactive elements (listitems or divs).
    1. `getByDisplayValue`: The current value of a form element can be useful
       when navigating a page with filled-in values.
 1. **Semantic Queries** HTML5 and ARIA compliant selectors. Note that the user

--- a/docs/guide-which-query.md
+++ b/docs/guide-which-query.md
@@ -14,6 +14,11 @@ possible. With this in mind, we recommend this order of priority:
    1. `getByLabelText`: Only really good for form fields, but this is the number
       one method a user finds those elements, so it should be your top
       preference.
+   1. `getByRole`: With the `name` option you can basically query the full
+      accessibility tree. It can query all the elements you can query with the
+      other accessility query. But consider that you still might want to assert
+      if an element has an actual `<label>` element or a `placeholder`
+      attribute.
    1. `getByPlaceholderText`:
       [A placeholder is not a substitute for a label](https://www.nngroup.com/articles/form-design-placeholders/).
       But if that's all you have, then it's better than alternatives.
@@ -29,8 +34,6 @@ possible. With this in mind, we recommend this order of priority:
       `area`, and `input`), then you can use this to find that element.
    1. `getByTitle`: The title attribute is not consistently read by
       screenreaders, and is not visible by default for sighted users
-   1. `getByRole`: This can be used to select dialog boxes and other
-      difficult-to-capture elements in a more semantic way
 1. **Test IDs**
    1. `getByTestId`: The user cannot see (or hear) these, so this is only
       recommended for cases where you can't match by role or text or it doesn't


### PR DESCRIPTION
Docs for https://github.com/testing-library/dom-testing-library/pull/408

Preview:
- https://deploy-preview-368--testing-library.netlify.com/docs/dom-testing-library/api-queries#byrole
- https://deploy-preview-368--testing-library.netlify.com/docs/guide-which-query

I moved `byRole` up in the recommendations. I'm not so sure if we should already do this though. Personally I would hope that we can reduce the queries to `byRole` and `byTestId` and then recommend asserting properties such as `placeholder`, `alt`, `value` etc. Choosing the right query is currently not trivial. Though I fear that by only having `byRole` we loose a lot of people because they are not aware of the role names and fall back to testid. While I would hope that everybody knows what roles are it's not mainstream knowledge as far as I can tell. And `<input />` having so many roles with names that are not that common in frontend development. I can only speak for myself though (mentally it's still "`input` of type `text`" instead of just "a `textbox`"). So I'm really looking forward to input from others that have teaching experience or can quickly poll their teams.

I'm fine with leaving the `name` option a bit more obscure for a start and see how  adoption goes. 