### PR TITLE
Update setup.md

### DIFF
--- a/docs/dom-testing-library/setup.md
+++ b/docs/dom-testing-library/setup.md
@@ -34,5 +34,5 @@ mocha --require jsdom-global/register
 ```
 
 > Note, depending on the version of Node you're running, you may also need to
-> install `@babel/polyfill` (if you're using babel 7) or `babel-polyfill` (for
-> babel 6).
+> add `core-js` and `regenerator-runtime` (if you're using babel 7) or 
+> `babel-polyfill` (for babel 6).


### PR DESCRIPTION
because @babel/polyfill is deprecated in 7.4.0 https://babeljs.io/docs/en/next/babel-polyfill