### PR TITLE
Fixed axios module default import name to match mock

### DIFF
--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect'
 import axiosMock from 'axios'
 import Fetch from '../fetch'
 
-jest.mock('axios')
+jest.mock('axiosMock')
 
 test('loads and displays greeting', async () => {
   const url = '/greeting'
@@ -57,7 +57,7 @@ import axiosMock from 'axios'
 import Fetch from '../fetch'
 
 // https://jestjs.io/docs/en/mock-functions#mocking-modules
-jest.mock('axios')
+jest.mock('axiosMock')
 ```
 
 ```jsx


### PR DESCRIPTION
Why:

The example provides a declarative import name ("axiosMock") in
anticipation for it being mocked but doesn't actually use this name
in the mock.

* ...

This change addresses the need by:
- updates module name from axios -> axiosMock in `Full Example` snippet
- updates module name from axios -> axiosMock in `Step-By-Step/Imports`
  snippet