### PR TITLE
Update Cypress documentation reference from getByLabelText to findByLabelText

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -182,7 +182,7 @@ const inputNode = getByLabelText('username')
 <!--Cypress-->
 
 ```js
-cy.getByLabelText('username').should('exist')
+cy.findByLabelText('username').should('exist')
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
Using the current command throws with

> Error: You used 'getByLabelText' which has been removed from Cypress Testing Library because it does not make sense in this context. Please use 'findByLabelText' instead.

This PR changes the command to `findByLabelText` as recommended by the error message