### PR TITLE
docs: add missing examples for vue-testing-library

### DIFF
--- a/docs/vue-testing-library/examples.md
+++ b/docs/vue-testing-library/examples.md
@@ -102,3 +102,5 @@ Some included are:
 - [`vuex`](https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vuex.js)
 - [`vue-router`](https://github.com/testing-library/vue-testing-library/tree/master/src/__tests__/vue-router.js)
 - [`vee-validate`](https://github.com/testing-library/vue-testing-library/tree/master/src/__tests__/validate-plugin.js)
+- [`vue-i18n`](https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vueI18n.js)
+- [`vuetify`](https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vuetify.js)


### PR DESCRIPTION
See also: https://github.com/testing-library/vue-testing-library\#more-examples