### PR TITLE
docs: remove `console.log` from `logRoles` example

### DIFF
--- a/docs/dom-testing-library/api-helpers.md
+++ b/docs/dom-testing-library/api-helpers.md
@@ -291,7 +291,7 @@ nav.innerHTML = `
   <li>Item 2</li>
 </ul>`
 
-console.log(logRoles(nav))
+logRoles(nav)
 
 // navigation:
 //


### PR DESCRIPTION
The `console.log` is redundant, may as well remove it 😄.