### PR TITLE
Updates clientScript instructions to use module

### DIFF
--- a/docs/testcafe-testing-library/intro.md
+++ b/docs/testcafe-testing-library/intro.md
@@ -27,7 +27,7 @@ Add the following to your .testcaferc.json file:
 
 ```json
   "clientScripts": [
-    "module":"@testing-library/dom/dist/@testing-library/dom.umd.js"
+    { "module": "@testing-library/dom/dist/@testing-library/dom.umd.js" }
   ],
 ```
 

--- a/docs/testcafe-testing-library/intro.md
+++ b/docs/testcafe-testing-library/intro.md
@@ -27,7 +27,7 @@ Add the following to your .testcaferc.json file:
 
 ```json
   "clientScripts": [
-    "./node_modules/@testing-library/dom/dist/@testing-library/dom.umd.js"
+    "module":"@testing-library/dom/dist/@testing-library/dom.umd.js"
   ],
 ```
 


### PR DESCRIPTION
Module is preferable to absolute file path as it doesn't assume the location of `node_modules` folder and works better with monorepos using yarn workspaces etc. where dependencies may be hoiseted.

This `{ "module": "npm module" }` syntax is documented here https://devexpress.github.io/testcafe/documentation/using-testcafe/configuration-file.html#clientscripts — see the example of how `"loadsh"` is loaded.