### PR TITLE
Update guide-disappearance to mention waitFor and change waitForElement to findBy

### DIFF
--- a/docs/guide-disappearance.md
+++ b/docs/guide-disappearance.md
@@ -17,12 +17,12 @@ test('movie title appears', async () => {
   // element is initially not present...
 
   // wait for appearance
-  await wait(() => {
+  await waitFor(() => {
     expect(getByText('the lion king')).toBeInTheDocument()
   })
 
   // wait for appearance and return the element
-  const movie = await waitForElement(() => getByText('the lion king'))
+  const movie = await findByText('the lion king')
 })
 ```
 
@@ -41,9 +41,9 @@ test('movie title no longer present in DOM', async () => {
 
 Using
 [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
-is more efficient than polling the DOM at regular intervals with `wait`.
+is more efficient than polling the DOM at regular intervals with `waitFor`.
 
-The `wait` [async helper][async-api] function retries until the wrapped function
+The `waitFor` [async helper][async-api] function retries until the wrapped function
 stops throwing an error. This can be used to assert that an element disappears
 from the page.
 
@@ -52,7 +52,7 @@ test('movie title goes away', async () => {
   // element is initially present...
   // note use of queryBy instead of getBy to return null
   // instead of throwing in the query itself
-  await wait(() => {
+  await waitFor(() => {
     expect(queryByText('i, robot')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Update to mention `waitFor` as it will replace `wait` and change `waitForElement` example to use `findBy` query instead.