### PR TITLE
docs: Fix event link to event map file

### DIFF
--- a/docs/dom-testing-library/api-events.md
+++ b/docs/dom-testing-library/api-events.md
@@ -29,7 +29,7 @@ fireEvent[eventName](node: HTMLElement, eventProperties: Object)
 ```
 
 Convenience methods for firing DOM events. Check out
-[src/events.js](https://github.com/testing-library/dom-testing-library/blob/master/src/events.js)
+[src/event-map.js](https://github.com/testing-library/dom-testing-library/blob/master/src/event-map.js)
 for a full list as well as default `eventProperties`.
 
 ```javascript


### PR DESCRIPTION
In this section of the DOM Testing Library docs for `fireEvent`: https://testing-library.com/docs/dom-testing-library/api-events#fireeventeventname

It seems like the link to the event options goes to a different place than intended.

![image](https://user-images.githubusercontent.com/17582916/78295075-bb30e580-74e8-11ea-9c1e-d0d87f9b08aa.png)

Link before: https://github.com/testing-library/dom-testing-library/blob/master/src/events.js

Link with this PR: https://github.com/testing-library/dom-testing-library/blob/master/src/event-map.js