### PR TITLE
findBy / findAllBy default timeout

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -34,7 +34,7 @@ return an empty array (`[]`) if no elements match.
 
 `findBy*` queries return a promise which resolves when an element is found which
 matches the given query. The promise is rejected if no element is found or if
-more than one element is found after a default timeout of `4500`ms. If you need
+more than one element is found after a default timeout of `1000`ms. If you need
 to find more than one element, then use `findAllBy`.
 
 > Note, this is a simple combination of `getBy*` queries and
@@ -46,7 +46,7 @@ to find more than one element, then use `findAllBy`.
 
 `findAllBy*` queries return a promise which resolves to an array of elements
 when any elements are found which match the given query. The promise is rejected
-if no elements are found after a default timeout of `4500`ms.
+if no elements are found after a default timeout of `1000`ms.
 
 ## Options
 


### PR DESCRIPTION
findBy / findAllBy default timeout is 1000ms and not 450ms

see: 
https://github.com/testing-library/dom-testing-library/blob/1b711a4a0143b532dc8258f9ceac1a1b36557ce0/src/config.js#L8
https://github.com/testing-library/dom-testing-library/blob/672f2316d49609572857e7de80251eb052c9cbd1/src/wait-for.js#L15

Thanks for your awesome work!