### PR TITLE
Update api-events.md

### DIFF
--- a/docs/dom-testing-library/api-events.md
+++ b/docs/dom-testing-library/api-events.md
@@ -64,18 +64,9 @@ fireEvent.change(getByLabelText(/picture/i), {
 element in the DOM and the key you want to fire.
 
 ```javascript
-fireEvent.keyDown(domNode, { key: 'Enter', code: 13 })
+fireEvent.keyDown(domNode, { key: 'Enter', code: 'Enter' })
 
-// note: you should set the charCode or it will be fallback to 0
-// will fire a KeyboardEvent with charCode = 13
-fireEvent.keyDown(domNode, { key: 'Enter', code: 13 })
-
-// If using event.which, be sure to set the keyCode or it will be fallback to 0
-// will fire a KeyboardEvent with expected which = 13
-fireEvent.keyDown(domNode, { key: 'Enter', keyCode: 13 })
-
-// will fire a KeyboardEvent with charCode = 65
-fireEvent.keyDown(domNode, { key: 'A', code: 65, charCode: 65 })
+fireEvent.keyDown(domNode, { key: 'A', code: 'KeyQ' })
 ```
 
 You can find out which key code to use at


### PR DESCRIPTION
code are wrong, see:
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code/code_values

charCode and keyCode are deprecated and should not be used any more:
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode