### PR TITLE
fixed a minor typo

### DIFF
--- a/docs/react-testing-library/setup.md
+++ b/docs/react-testing-library/setup.md
@@ -214,7 +214,7 @@ _Typescript config needs to be updated as follow:_
     // ...,
 +   "baseUrl": "src",
 +   "paths": {
-+     "test-utils": ["../utils/test-utils"]
++     "test-utils": ["./utils/test-utils"]
 +   }
   }
 }


### PR DESCRIPTION
that can still cause a lot of confusion :)

it should be (only one dot)
```js 
"test-utils": ["./utils/test-utils"]
```

instead of 

```js 
"test-utils": ["../utils/test-utils"]
``` 