### PR TITLE
[docs] add await to example in userEvent.type for page example in testing-library.com/docs/ecosystem-user-event

### DIFF
--- a/docs/ecosystem-user-event.md
+++ b/docs/ecosystem-user-event.md
@@ -19,7 +19,7 @@ import userEvent from '@testing-library/user-event'
 test('click', () => {
   const { getByRole } = render(<textarea />)
 
-  userEvent.type(getByRole('textbox'), 'Hello, World!')
+  await userEvent.type(getByRole('textbox'), 'Hello, World!')
   expect(getByRole('textbox')).toHaveAttribute('value', 'Hello, World!')
 })
 ```


### PR DESCRIPTION
Made the change in the demo here https://testing-library.com/docs/ecosystem-user-event

```diff
- userEvent.type(getByRole('textbox'), 'Hello, World!')
+ await userEvent.type(getByRole('textbox'), 'Hello, World!')
```