### PR TITLE
fixed example code typo

### DIFF
--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -87,7 +87,7 @@ axiosMock.get.mockResolvedValueOnce({
   data: { greeting: 'hello there' },
 })
 
-fireEvent.click(getByText('Load Greeting'))
+fireEvent.click(screen.getByText('Load Greeting'))
 
 // Wait until the mocked `get` request promise resolves and
 // the component calls setState and re-renders.


### PR DESCRIPTION
Found a small typo in the example code when working through the React tutorial