### PR TITLE
docs(vue-testing-library): fix broken stub example link in VTL docs

### DIFF
--- a/docs/vue-testing-library/faq.md
+++ b/docs/vue-testing-library/faq.md
@@ -90,6 +90,6 @@ Links:
 [vue-test-utils]: https://github.com/vuejs/vue-test-utils
 [mount]: https://vue-test-utils.vuejs.org/api/#mount
 [stubs]: https://vue-test-utils.vuejs.org/api/options.html#stubs
-[stubs-example]: https://github.com/testing-library/vue-testing-library/blob/master/tests/__tests__/stubs.js
+[stubs-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/stubs.js
 
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
The link to stub example in [FAQ page](https://testing-library.com/docs/vue-testing-library/faq) of VTL is broken. It links to a 404 page now.

I think you want to link to stubs.js in https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/stubs.js. Therefore, I change to the link to that file.