### PR TITLE
docs: add links to testing-playground.com

### DIFF
--- a/docs/example-codesandbox.md
+++ b/docs/example-codesandbox.md
@@ -9,3 +9,8 @@ You can find runnable examples for many common use cases on Codesandbox.
 [![Open react-testing-library-examples](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/kentcdodds/react-testing-library-examples/tree/master/)
 
 <iframe src="https://codesandbox.io/embed/github/kentcdodds/react-testing-library-examples/tree/master/?expanddevtools=1&fontsize=13&hidenavigation=1&initialpath=%2F__tests__%2Fasync.js&module=%2Fsrc%2F__tests__%2Fasync.js&moduleview=1&previewwindow=tests&view=editor" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+
+## Playground
+
+Are you looking for a quick way to run queries against your own html instead?
+Try [testing-playground.com](https://testing-playground.com)

--- a/docs/example-external.md
+++ b/docs/example-external.md
@@ -9,6 +9,11 @@ sidebar_label: External Examples
 - You can find more React Testing Library examples at
   [react-testing-examples.com](https://react-testing-examples.com/jest-rtl/).
 
+## Playground
+
+- An interactive sandbox with visual feedback on different queries
+  [testing-playground.com](https://testing-playground.com).
+
 ## Videos
 
 - [What is React Testing Library?](https://youtu.be/JKOwJUM4_RM) by Scott

--- a/docs/guide-which-query.md
+++ b/docs/guide-which-query.md
@@ -19,7 +19,8 @@ possible. With this in mind, we recommend this order of priority:
       top preference for just about everything. There's not much you can't get
       with this (if you can't, it's possible your UI is inaccessible). Most
       often, this will be used with the `name` option like so:
-      `getByRole('button', {name: /submit/i})`. Check the [list of roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#Roles).
+      `getByRole('button', {name: /submit/i})`. Check the
+      [list of roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#Roles).
    1. `getByLabelText`: Only really good for form fields, but this is the number
       one method a user finds those elements, so it should be your top
       preference.
@@ -55,3 +56,10 @@ testid if you have to.
 const { container } = render(<MyComponent />)
 const foo = container.querySelector('[data-foo="bar"]')
 ```
+
+## Playground
+
+If you want to get more familiar with these queries, you can try them out on
+[testing-playground.com](https://testing-playground.com). Testing Playground is
+an interactive sandbox where you can run different queries against your own
+html, and get visual feedback matching the rules mentioned above.


### PR DESCRIPTION
As talked about on [Twitter](https://twitter.com/TestingLib/status/1262764875127742466?s=20), I've added a link to [testing-playground.com](https://testing-playground.com) to the docs. I've done this in three different places. Feel free to correct me in case I've taken the `somewhere where people won't miss it` a bit too literally :innocent: 

I've also thought about adding a link to the footer or sidebar instead, but it didn't really match there with anything else. Let me know if you think otherwise. The docs are huge! (which is a good thing), so this is a long shot, which I'm sure can be improved.

Anyways, what I've done:

## [Codesandbox Examples](https://testing-library.com/docs/example-codesandbox)

**Added**:

> **Playground**
> 
> Are you looking for a quick way to run queries against your own html instead? Try [testing-playground.com](https://testing-playground.com)

**Reasoning**:

The title `Codesandbox Examples` doesn't really include space for the playground. But I do believe that people will look at that page when they go search for something to play with.

## [External Examples](https://testing-library.com/docs/example-external.html)

**Added**:

> **Playground**
>
>-  An interactive sandbox with visual feedback on different queries [testing-playground.com](https://testing-playground.com).

**Reasoning**:

As [testing-library.com](https://testing-library.com) is an external project, I believe this is where it fits best. At the same time, I don't expect that many people will look at this page. 

## [Which query should I use?](https://testing-library.com/docs/guide-which-query)

**Added**:

> **Playground**
> 
> If you want to get more familiar with these queries, you can try them out on [testing-playground.com](https://testing-playground.com). Testing Playground is an interactive sandbox where you can run different queries against your own html, and get visual feedback matching the rules mentioned above.

**Reasoning**:

I think this is my boldest addition. The reason to add it here is that this page is the entire idea behind the playground. Testing Playground analyzes your query and makes a recommendation to improve it, based on the principles explained on this page.

## Other considerations I've made

- I've thought about adding it to the footer, but it doesn't really match the content there.
- I've thought about adding a dedicated link to the sidebar but wasn't sure where.

## Remaining

I'm open to suggestions to improve the texts and locations to match better with the docs.

Thanks for this awesome library! I'm glad that I've found a way (with the playground) to contribute back to this community.