### PR TITLE
Add example of firing select event

### DIFF
--- a/docs/react-testing-library/faq.md
+++ b/docs/react-testing-library/faq.md
@@ -28,6 +28,20 @@ test('change values via the fireEvent.change method', () => {
   expect(input.value).toBe('a')
 })
 
+test('select drop-downs must use the fireEvent.change', () => {
+  const handleChange = jest.fn()
+  const { container } = render(<select onChange={handleChange}><option value="1">1</option><option value="2">2</option></select>)
+  const select = container.firstChild;
+  const option1 = container.getElementsByTagName("option").item(0);
+  const option2 = container.getElementsByTagName("option").item(1);
+        
+  fireEvent.change(select, {target: {value: "2"}});
+
+  expect(handleChange).toHaveBeenCalledTimes(1);
+  expect(option1.selected).toBe(false);
+  expect(option2.selected).toBe(true);
+})
+
 test('checkboxes (and radios) must use fireEvent.click', () => {
   const handleChange = jest.fn()
   const { container } = render(


### PR DESCRIPTION
As a new user of this library I had a difficult time determining how to test outcomes of a drop-down selection.  There is an example if you use the react-select library but very little information on the internet if you use a plain select tag.

I found Kent's comment on an issue in the react-testing-library and thought it would be helpful to others to add it to the FAQs.  https://github.com/testing-library/react-testing-library/issues/322