### PR TITLE
Adds comma to the subtitle in the ByLabelText section

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -115,7 +115,7 @@ screen.debug(screen.getAllByText('multi-test'))
 
 ### `ByLabelText`
 
-> getByLabelText, queryByLabelText, getAllByLabelText, queryAllByLabelText
+> getByLabelText, queryByLabelText, getAllByLabelText, queryAllByLabelText,
 > findByLabelText, findAllByLabelText
 
 ```typescript


### PR DESCRIPTION
This PR adds a comma to the subtitle in the ByLabelText section after the queryAllByLabelText