### PR TITLE
Fix typos

### DIFF
--- a/docs/example-react-intl.md
+++ b/docs/example-react-intl.md
@@ -74,7 +74,7 @@ const renderWithReactIntl = component => {
 
 setupTests()
 
-test('it should render FormattedDate and have a formated pt date', () => {
+test('it should render FormattedDate and have a formatted pt date', () => {
   const { container } = renderWithReactIntl(<FormatDateView />)
   expect(getByTestId(container, 'date-display')).toHaveTextContent('11/03/2019')
 })

--- a/docs/vue-testing-library/api.md
+++ b/docs/vue-testing-library/api.md
@@ -213,7 +213,7 @@ await fireEvent.blur(getByLabelText('username'))
 ### `update(elem, value)`
 
 Properly handles inputs controlled by `v-model`. It updates the
-input/select/textarea inner value while emitting the appropiate native event.
+input/select/textarea inner value while emitting the appropriate native event.
 
 See a working example of `update` in the
 [v-model example test](/docs/vue-testing-library/examples#example-using-v-model).


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `docs/example-react-intl.md`
- 1 typo in `docs/vue-testing-library/api.md`



Bye! :robot: