### PR TITLE
docs: replace "axiosMock" with "msw" in React Testing Library example

### DIFF
--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -64,7 +64,22 @@ import { render, fireEvent, waitFor, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 // the component to test
 import Fetch from '../fetch'
+```
 
+```jsx
+test('loads and displays greeting', async () => {
+  // Arrange
+  // Act
+  // Assert
+})
+```
+
+### Mock
+
+Use the `setupServer` function from `msw` to mock an API request that our tested
+component makes.
+
+```js
 // declare which API requests to mock
 const server = setupServer(
   // capture "GET /greeting" requests
@@ -78,14 +93,6 @@ const server = setupServer(
 // and clean up once the tests are finished
 beforeAll(() => server.listen())
 afterAll(() => server.close())
-```
-
-```jsx
-test('loads and displays greeting', async () => {
-  // Arrange
-  // Act
-  // Assert
-})
 ```
 
 ### Arrange

--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -39,6 +39,10 @@ test('loads and displays greeting', async () => {
 })
 ```
 
+> We recommend using [Mock Service Worker](https://github.com/mswjs/msw) library
+> to declaratively mock API communication in your tests instead of stubbing
+> `window.fetch`, or relying on third-party adapters.
+
 ---
 
 ## Step-By-Step
@@ -50,7 +54,6 @@ test('loads and displays greeting', async () => {
 import React from 'react'
 
 // import API mocking utilities from Mock Service Worker
-// (see https://github.com/mswjs/msw)
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 

--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -145,28 +145,3 @@ export default function Fetch({ url }) {
   )
 }
 ```
-
-```jsx
-expect(screen.getByRole('heading')).toHaveTextContent('hello there')
-expect(screen.getByRole('button')).toHaveAttribute('disabled')
-
-// snapshots work great with regular DOM nodes!
-expect(container).toMatchInlineSnapshot(`
-  <div>
-    <div>
-      <button
-        disabled=""
-      >
-        Ok
-      </button>
-      <h1>
-        hello there
-      </h1>
-    </div>
-  </div>
-`)
-
-// you can also use get a `DocumentFragment`,
-// which is useful if you want to compare nodes across render
-expect(asFragment()).toMatchSnapshot()
-```


### PR DESCRIPTION
## Changes

- Removes the usage of `jest.mock` and `axiosMock.get.mockResolvedValueOnce()` in favor of a more declarative approach (see the reasoning in the GitHub issue).
- Updates the "Step-by-step" section to briefly explain why `msw` has been added, and what each of its usage steps means.

## GitHub

- Closes #482 

## Notes

This was the only usage example I've found that illustrates testing a component that performs requests. Please, if I missed something, would you suggest me where to look for similar examples in the documentation? Thanks!