### PR TITLE
fix typo in example-intro.md

### DIFF
--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -173,8 +173,10 @@ function greetingReducer(state, action) {
       }
     }
     case: 'ERROR': {
-      error: action.error,
-      greeting: null
+      return {
+        error: action.error,
+        greeting: null
+      }
     }
     default: {
       return state


### PR DESCRIPTION
- [x] Fix small typo in docs
Thanks for the little "Edit" button it makes editing way easier.