### PR TITLE
Elevate fire event page in prep for merge

### DIFF
--- a/docs/angular-testing-library/api.md
+++ b/docs/angular-testing-library/api.md
@@ -288,9 +288,7 @@ are automatically bound to the Angular Component. This to ensure that the
 Angular change detection has been run by invoking `detectChanges` after an event
 has been fired.
 
-See
-[Firing Events](https://testing-library.com/docs/dom-testing-library/api-events)
-for a complete list.
+See [Firing Events](universal-api-events.md) for a complete list.
 
 **example**:
 

--- a/docs/dom-testing-library/cheatsheet.md
+++ b/docs/dom-testing-library/cheatsheet.md
@@ -93,7 +93,8 @@ See [Async API](dom-testing-library/api-async.md)
 
 ## Events
 
-See [Considerations for fireEvent](guide-events.md), [Events API](api-events.md)
+See [Considerations for fireEvent](guide-events.md),
+[Events API](universal-api-events.md)
 
 - **fireEvent** trigger DOM event: `fireEvent(node, event)`
 - **fireEvent.\*** helpers for default event types

--- a/docs/preact-testing-library/api.md
+++ b/docs/preact-testing-library/api.md
@@ -81,9 +81,8 @@ Even thought it's for React, it gives you an idea of why it's needed.
 
 ## `fireEvent`
 
-Passes it to the @testing-library/dom
-[fireEvent](../dom-testing-library/api-events). It's also wrapped in `act` so
-you don't need to worry about doing it.
+Passes it to the @testing-library/dom [fireEvent](../universal-api-events). It's
+also wrapped in `act` so you don't need to worry about doing it.
 
 📝 Keep in mind mainly when using `h / Preact.createElement` that React uses a
 Synthetic event system, and Preact uses the browser's native `addEventListener`

--- a/docs/preact-testing-library/learn.md
+++ b/docs/preact-testing-library/learn.md
@@ -16,7 +16,7 @@ If you're still hungry for more at this point than checkout:
 - The dom-testing-library:
   - [Introduction](../intro.md)
   - [Queries](../dom-testing-library/api-queries)
-  - [Firing Events](../dom-testing-library/api-events)
+  - [Firing Events](../universal-api-events)
   - [Async Utilities](../dom-testing-library/api-async.md)
   - [Helpers](../dom-testing-library/api-helpers)
   - [FAQ](../dom-testing-library/faq.md)

--- a/docs/react-testing-library/cheatsheet.md
+++ b/docs/react-testing-library/cheatsheet.md
@@ -122,7 +122,7 @@ See [dom-testing-library Async API](dom-testing-library/api-async.md)
 
 ## Events
 
-See [Events API](dom-testing-library/api-events.md)
+See [Events API](universal-api-events.md)
 
 - **fireEvent** trigger DOM event: `fireEvent(node, event)`
 - **fireEvent.\*** helpers for default event types

--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -140,8 +140,8 @@ const { container, asFragment } = render(<Fetch url="/greeting" />)
 
 ### Act
 
-The [`fireEvent`](dom-testing-library/api-events.md) method allows you to fire
-events to simulate user actions.
+The [`fireEvent`](universal-api-events.md) method allows you to fire events to
+simulate user actions.
 
 ```jsx
 fireEvent.click(screen.getByText('Load Greeting'))

--- a/docs/svelte-testing-library/api.md
+++ b/docs/svelte-testing-library/api.md
@@ -71,7 +71,7 @@ const { results } = render(YourComponent, { myProp: 'value' })
 | `debug`      | Logs the `container` using [prettyDom](https://testing-library.com/docs/dom-testing-library/api-helpers#prettydom).                                                                                                                                                                                                                                                                                                                                                                                 |
 | `unmount`    | Unmounts the component from the `target` by calling `component.$destroy()`.                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `rerender`   | Calls render again destroying the old component, and mounting the new component on the original `target` with any new options passed in.                                                                                                                                                                                                                                                                                                                                                            |
-| `...queries` | Returns all [query functions](https://testing-library.com/docs/dom-testing-library/api-queries) that are bound to the `container`. If you pass in `query` arguments than this will be those, otherwise all.                                                                                                                                                                                                                                                                                        |
+| `...queries` | Returns all [query functions](https://testing-library.com/docs/dom-testing-library/api-queries) that are bound to the `container`. If you pass in `query` arguments than this will be those, otherwise all.                                                                                                                                                                                                                                                                                         |
 
 ## `cleanup`
 
@@ -104,9 +104,9 @@ DOM.
 
 ## `fireEvent` (`async`)
 
-Calls `@testing-library/dom` [fireEvent](../dom-testing-library/api-events). It
-is an `async` method due to calling [`tick`][svelte-tick] which tells Svelte to
-flush all pending state changes, basically it updates the DOM to reflect the new
+Calls `@testing-library/dom` [fireEvent](../universal-api-events). It is an
+`async` method due to calling [`tick`][svelte-tick] which tells Svelte to flush
+all pending state changes, basically it updates the DOM to reflect the new
 changes.
 
 **Component**

--- a/docs/universal-api-events.md
+++ b/docs/universal-api-events.md
@@ -1,5 +1,5 @@
 ---
-id: api-events
+id: universal-api-events
 title: Firing Events
 ---
 
@@ -59,10 +59,10 @@ fireEvent.change(getByLabelText(/picture/i), {
 })
 ```
 
-**dataTransfer**: Drag events have a `dataTransfer` property that contains
-data transferred during the operation. As a convenience, if you provide a
-`dataTransfer` property in the `eventProperties` (second argument), then
-those properties will be added to the event.
+**dataTransfer**: Drag events have a `dataTransfer` property that contains data
+transferred during the operation. As a convenience, if you provide a
+`dataTransfer` property in the `eventProperties` (second argument), then those
+properties will be added to the event.
 
 This should predominantly be used for testing drag and drop interactions.
 
@@ -111,8 +111,8 @@ You can also create generic events:
 fireEvent(
   input,
   createEvent('input', input, {
-    target: {files: inputFiles},
+    target: { files: inputFiles },
     ...init,
-  }),
+  })
 )
 ```

--- a/docs/vue-testing-library/api.md
+++ b/docs/vue-testing-library/api.md
@@ -189,7 +189,7 @@ It returns a Promise through `wait()`, so you can `await updateProps(...)`.
 ## `fireEvent`
 
 Vue Testing Library re-exports all DOM Testing Library
-[firing events](https://deploy-preview-132--testing-library.netlify.com/docs/dom-testing-library/api-events).
+[firing events](https://deploy-preview-132--testing-library.netlify.com/docs/universal-api-events).
 However, it alters them so that all events are async.
 
 ```js

--- a/docs/vue-testing-library/cheatsheet.md
+++ b/docs/vue-testing-library/cheatsheet.md
@@ -73,7 +73,7 @@ For more information, see
   - **input** `fireEvent.input(node, event)`
   - [See all supported events](https://github.com/testing-library/dom-testing-library/blob/master/src/event-map.js)
 
-For more information, see [Events API](dom-testing-library/api-events.md)
+For more information, see [Events API](universal-api-events.md)
 
 > **Difference from DOM Testing Library**
 >

--- a/netlify.toml
+++ b/netlify.toml
@@ -41,6 +41,13 @@
   status = 301
   force = false # do not redirect if route is not 404
 
+# DTL fire event page to universal user event page due to merge
+[[redirects]]
+  from = "https://testing-library.com/docs/dom-testing-library/api-events"
+  to = "https://testing-library.com/docs/universal-api-events"
+  status = 301
+  force = true
+
 # DOM landing page to home page
 [[redirects]]
   from = "https://testing-library.com/dom/"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,6 +1,6 @@
 {
   "docs": {
-    "Getting Started": ["intro", "guiding-principles"],
+    "Getting Started": ["intro", "guiding-principles", "universal-api-events"],
     "Frameworks": [
       {
         "type": "subcategory",
@@ -11,7 +11,6 @@
           "dom-testing-library/example-intro",
           "dom-testing-library/setup",
           "dom-testing-library/api-queries",
-          "dom-testing-library/api-events",
           "dom-testing-library/api-async",
           "dom-testing-library/api-helpers",
           "dom-testing-library/api-configuration",


### PR DESCRIPTION
As per conversation on #490 (and #485), the event firing utilities are largely universal and independent of the testing library family products they're imported into

This PR moves [the existing Fire Event page](https://testing-library.com/docs/dom-testing-library/api-events) from its nested folder in DOM Testing Library to the top level in preparation for it to be merged with the [docs from User Event](https://github.com/testing-library/user-event)

@MatanBobi had begun working on #485 so I followed his model for the page structure to keep things consistent

This PR includes a 301 Redirect which, assuming I implemented it correctly, will cover all traffic going to the original Fire Event page and make this a non-breaking change

![Screen Shot 2020-06-15 at 11 57 28 PM](https://user-images.githubusercontent.com/5633704/84730793-38ef8380-af65-11ea-91c0-cc0d9a4049d4.png)

I'm interested in any feedback or pushback with the goal of being able to migrate the [docs from User Event](https://github.com/testing-library/user-event) to this repository in short order