### PR TITLE
Correct Assert section in Example page of React Testing Library

### DIFF
--- a/docs/react-testing-library/example-intro.md
+++ b/docs/react-testing-library/example-intro.md
@@ -158,6 +158,16 @@ await waitFor(() =>
 
 ### Assert
 
+```jsx
+// assert that the alert message is correct.
+expect(screen.getByRole('alert')).toHaveTextContent('Oops, failed to fetch!')
+
+// assert that the button is not disabled.
+expect(screen.getByRole('button')).not.toHaveAttribute('disabled')
+```
+
+### System Under Test
+
 fetch.js
 
 ```jsx


### PR DESCRIPTION
Assert section in Example page of React Testing Library does not
contains assertion code but SUT. So rename the section to
'System Under Test' and insert a new section that describes assertion
code correctly.