### PR TITLE
Add documentation for queryFallback

### DIFF
--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -605,6 +605,7 @@ getByRole(
     name?: TextMatch,
     normalizer?: NormalizerFn,
     selected?: boolean,
+    queryFallbacks?: boolean,
   }): HTMLElement
 ```
 
@@ -709,6 +710,10 @@ cy.findByRole('dialog').should('exist')
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
+
+You may also want to select an element by any role in its fallbacks, rather than the literal value of the `role` attribute. You can use `queryFallbacks: true` to selectively enable this functionality in specific queries.
+
+> An element doesn't have multiple roles in a given environment. It has a single one. Multiple roles in the attribute are evaluated from left to right until the environment finds the first role it understands. This is useful when new roles get introduced and you want to start supporting those as well as older environments that don't understand that role (yet).
 
 ### `ByTestId`
 

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -711,7 +711,7 @@ cy.findByRole('dialog').should('exist')
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-By default, it's assumed that the first role of each element is supported, so only the first role can be queried. If you need to query an element by any role in its fallbacks instead, you can use `queryFallbacks: true`.
+By default, it's assumed that the first role of each element is supported, so only the first role can be queried. If you need to query an element by any of its fallback roles instead, you can use `queryFallbacks: true`.
 
 > An element doesn't have multiple roles in a given environment. It has a single one. Multiple roles in the attribute are evaluated from left to right until the environment finds the first role it understands. This is useful when new roles get introduced and you want to start supporting those as well as older environments that don't understand that role (yet).
 

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -713,6 +713,8 @@ cy.findByRole('dialog').should('exist')
 
 By default, it's assumed that the first role of each element is supported, so only the first role can be queried. If you need to query an element by any of its fallback roles instead, you can use `queryFallbacks: true`.
 
+For example, `getByRole('switch')` would always match `<div role="switch checkbox" />` because it's the first role, while `getByRole('checkbox')` would not. However, `getByRole('checkbox', { queryFallbacks: true })` would enable all fallback roles and therefore match the same element.
+
 > An element doesn't have multiple roles in a given environment. It has a single one. Multiple roles in the attribute are evaluated from left to right until the environment finds the first role it understands. This is useful when new roles get introduced and you want to start supporting those as well as older environments that don't understand that role (yet).
 
 ### `ByTestId`

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -711,7 +711,7 @@ cy.findByRole('dialog').should('exist')
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-You may also want to select an element by any role in its fallbacks, rather than the literal value of the `role` attribute. You can use `queryFallbacks: true` to selectively enable this functionality in specific queries.
+By default, it's assumed that the first role of each element is supported, so only the first role can be queried. If you need to query an element by any role in its fallbacks instead, you can use `queryFallbacks: true`.
 
 > An element doesn't have multiple roles in a given environment. It has a single one. Multiple roles in the attribute are evaluated from left to right until the environment finds the first role it understands. This is useful when new roles get introduced and you want to start supporting those as well as older environments that don't understand that role (yet).
 


### PR DESCRIPTION
It seems like #386 hasn't been fixed yet, so I added some information about `queryFallbacks` based on the `dom-testing-library` type and documentation text suggested in the issue. Feel free to suggest better wording/organization.

**Preview:** Scroll to the bottom of this section https://deploy-preview-518--testing-library.netlify.app/docs/dom-testing-library/api-queries#byrole