### PR TITLE
docs(angular): update link to Angular examples

### DIFF
--- a/docs/angular-testing-library/examples.md
+++ b/docs/angular-testing-library/examples.md
@@ -60,7 +60,7 @@ describe('Counter', () => {
 ```
 
 More examples can be found in the
-[GitHub project](https://github.com/testing-library/angular-testing-library/tree/master/src/app/examples).
+[GitHub project](https://github.com/testing-library/angular-testing-library/tree/master/apps/example-app/app/examples).
 These examples include:
 
 - `@Input` and `@Output` properties


### PR DESCRIPTION
The angular example repo was recently migrated to Nx, which broke the link from this repo to those examples