### PR TITLE
update api-events target example to warn about using valid target val…

### DIFF
--- a/docs/dom-testing-library/api-events.md
+++ b/docs/dom-testing-library/api-events.md
@@ -58,7 +58,7 @@ fireEvent.change(getByLabelText(/picture/i), {
   },
 })
 
-// note: The value attribute must abide by ISO 8601 standards when firing a 
+// Note: The 'value' attribute must use ISO 8601 format when firing a 
 // change event on an input of type "date". Otherwise the element will not 
 // reflect the changed value.
 

--- a/docs/dom-testing-library/api-events.md
+++ b/docs/dom-testing-library/api-events.md
@@ -57,6 +57,16 @@ fireEvent.change(getByLabelText(/picture/i), {
     files: [new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' })],
   },
 })
+
+// note: The value attribute must abide by ISO 8601 standards when firing a 
+// change event on an input of type "date". Otherwise the element will not 
+// reflect the changed value.
+
+// Invalid:
+fireEvent.change(input, { target: { value: '12/05/2020' } })
+
+// Valid:
+fireEvent.change(input, { target: { value: '2020-05-12' } })
 ```
 
 **dataTransfer**: Drag events have a `dataTransfer` property that contains


### PR DESCRIPTION
…ue (date example). Closes #385 