### PR TITLE
docs(svelte): add reference to typescript

### DIFF
--- a/docs/svelte-testing-library/setup.md
+++ b/docs/svelte-testing-library/setup.md
@@ -74,20 +74,10 @@ with any testing framework and runner you're comfortable with.
 
 ## Typescript
 
-In order to support Typescript, you need to enable `preprocess`.
-
-1. Update your jest configuration
-
-  ```json
-  {
-    "jest": {
-      "transform": {
-        "^.+\\.svelte$": ["svelte-jester", { "preprocess": true }]
-      },
-      "moduleFileExtensions": ["js", "ts", "svelte"]
-    }
-  }
-  ```
+To use Typescript, you'll need to install and configure `svelte-preprocess` and
+`ts-jest`. For full instructions, see the
+[`svelte-jester` docs](https://github.com/mihar-22/svelte-jester#typescript)
+docs.
 
 ## Babel / Preprocessors
 


### PR DESCRIPTION
I currently have [this PR open](https://github.com/mihar-22/svelte-jester/pull/10) in `svelte-jester` to make it a bit clearer how to get svelte-testing-library to play nice with TypeScript.

Assuming that that gets merged (or something like it), I thought it would be good to add a reference to TypeScript here in the testing-library docs, just so the breadcrumbs are a little easier to follow for a newbie setting up svelte-testing-library who is also using TypeScript. That's what this PR does 🙂 