### PR TITLE
docs(example-reach-router): add example of route with parameters

### DIFF
--- a/docs/example-reach-router.md
+++ b/docs/example-reach-router.md
@@ -72,4 +72,35 @@ test('landing on a bad page', () => {
   // normally I'd use a data-testid, but just wanted to show this is also possible
   expect(container.innerHTML).toMatch('No match')
 })
+
+// If your route component has parameters, you'll have to change the render function a little bit
+// example of a route component with parameter
+const Routes = () => (
+  <Router>
+    <SomeComponent path="/some-component/:id" />
+  </Router>
+)
+
+// render function with Router wrapper from @reach/router
+function renderWithRouterWrapper(
+  ui,
+  { route = '/', history = createHistory(createMemorySource(route)) } = {}
+) {
+  return {
+    ...render(
+      <LocationProvider history={history}>
+        <Router>{ui}</Router>
+      </LocationProvider>
+    ),
+    history,
+  }
+}
+
+test('renders the component with params', () => {
+  // you'll have to declare the path prop in the component, exactly like the route
+  renderWithRouterWrapper(<SomeComponent path="/some-component/:id" />, {
+    // and pass the parameter value on the route config
+    route: '/some-component/1',
+  })
+})
 ```


### PR DESCRIPTION
I just add an example of how to test route components with parameters with `@reach/router`.

Previously I had problems testing this type of component, there are very few examples demonstrating this with `@reach/router`, so I decided to publish this example. 🙂