### PR TITLE
Add `timeout` to configuration docs

### DIFF
--- a/docs/dom-testing-library/api-configuration.md
+++ b/docs/dom-testing-library/api-configuration.md
@@ -44,6 +44,13 @@ and related queries. Defaults to `data-testid`.
 [`getBy*`](api-queries#getby) or [`getAllBy*`](api-queries#getallby) fail. Takes
 the error message and container object as arguments.
 
+`getElementError`: A function that returns the error used when
+[`getBy*`](api-queries#getby) or [`getAllBy*`](api-queries#getallby) fail. Takes
+the error message and container object as arguments.
+
+`timeout`: The global timeout value in milliseconds used by `waitFor` utilities. 
+Defaults to 1000ms. 
+
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--Native-->


### PR DESCRIPTION
According to the release notes for `dom-testing-library@7` (https://github.com/testing-library/dom-testing-library/releases/tag/v7.0.0), this is configurable at the global level.

I also wanted to fix the docusaurus code tabs because they don't seem to register new lines (which is confusing), but... that seems to also be a problem in the docusaurus documentation itself: https://docusaurus.io/docs/en/doc-markdown#language-specific-code-tabs Don't know if anyone has any ideas on that.