### PR TITLE
docs: fix `api-queries.md` minor grammar typos and "Note" block styles

### DIFF
--- a/docs/dom-testing-library/api-configuration.md
+++ b/docs/dom-testing-library/api-configuration.md
@@ -58,8 +58,8 @@ the error message and container object as arguments.
 [`getBy*`](api-queries#getby) or [`getAllBy*`](api-queries#getallby) fail. Takes
 the error message and container object as arguments.
 
-`timeout`: The global timeout value in milliseconds used by `waitFor` utilities. 
-Defaults to 1000ms. 
+`timeout`: The global timeout value in milliseconds used by `waitFor` utilities.
+Defaults to 1000ms.
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/docs/dom-testing-library/api-events.md
+++ b/docs/dom-testing-library/api-events.md
@@ -3,8 +3,9 @@ id: api-events
 title: Firing Events
 ---
 
-> Most projects have a few use cases for `fireEvent`, but the majority of the time you should
-> probably use [`@testing-library/user-event`](https://github.com/testing-library/user-event).
+> Most projects have a few use cases for `fireEvent`, but the majority of the
+> time you should probably use
+> [`@testing-library/user-event`](https://github.com/testing-library/user-event).
 
 ## `fireEvent`
 

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -226,8 +226,8 @@ const inputNode = screen.getByLabelText('Username', { selector: 'input' })
 
 > **Note** 
 >
-> `getByLabelText` will not work in the case where a `for` attr on a `<label>` 
-> element matches and `id` field on a non-form element.
+> `getByLabelText` will not work in the case where a `for` attribute on a
+> `<label>` element matches an `id` attribute on a non-form element.
 
 
 ```js

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -38,7 +38,7 @@ more than one element is found after a default timeout of `1000`ms. If you need
 to find more than one element, then use `findAllBy`.
 
 > **Note**
-> 
+>
 > this is a simple combination of `getBy*` queries and
 > [`waitFor`](/docs/api-async#waitfor). The `findBy*` queries accept the
 > `waitFor` options as the last argument. (i.e.
@@ -224,11 +224,10 @@ If it is important that you query an actual `<label>` element you can provide a
 const inputNode = screen.getByLabelText('Username', { selector: 'input' })
 ```
 
-> **Note** 
+> **Note**
 >
 > `getByLabelText` will not work in the case where a `for` attribute on a
 > `<label>` element matches an `id` attribute on a non-form element.
-
 
 ```js
 // This case is not valid
@@ -635,7 +634,13 @@ Queries for elements with the given role (and it also accepts a
 attribute. Here you can see
 [a table of HTML elements with their default and desired roles](https://www.w3.org/TR/html-aria/#docconformance).
 
-Please note that setting a `role` and/or `aria-*` attribute that matches the implicit ARIA semantics is unnecessary and is **not recomended** as these properties are already set by the browser, and we must not use the `role` and `aria-*` attributes in a manner that conflicts with the semantics described. For example, a `button` element can't have the `role` attribute of `heading`, because the `button` element has default characteristics that conflict with the `heading` role.
+Please note that setting a `role` and/or `aria-*` attribute that matches the
+implicit ARIA semantics is unnecessary and is **not recomended** as these
+properties are already set by the browser, and we must not use the `role` and
+`aria-*` attributes in a manner that conflicts with the semantics described. For
+example, a `button` element can't have the `role` attribute of `heading`,
+because the `button` element has default characteristics that conflict with the
+`heading` role.
 
 > Roles are matched literally by string equality, without inheriting from the
 > ARIA role hierarchy. As a result, querying a superclass role like `checkbox`
@@ -727,15 +732,14 @@ state and which elements can have this state see
 [ARIA `aria-checked`](https://www.w3.org/TR/wai-aria-1.2/#aria-checked).
 
 > **Note**
-> 
-> Checkboxes have a "mixed" state, which is considered neither checked
-> nor unchecked (details
-> [here](https://www.w3.org/TR/html-aam-1.0/#details-id-56)).
+>
+> Checkboxes have a "mixed" state, which is considered neither checked nor
+> unchecked (details [here](https://www.w3.org/TR/html-aam-1.0/#details-id-56)).
 
 #### `pressed`
 
-Buttons can have a pressed state. You can filter the returned elements by
-their pressed state by setting `pressed: true` or `pressed: false`.
+Buttons can have a pressed state. You can filter the returned elements by their
+pressed state by setting `pressed: true` or `pressed: false`.
 
 For example in
 
@@ -748,9 +752,8 @@ For example in
 </body>
 ```
 
-you can get the "👍" button by calling
-`getByRole('button', { pressed: true })`. To learn more about the pressed
-state see
+you can get the "👍" button by calling `getByRole('button', { pressed: true })`.
+To learn more about the pressed state see
 [ARIA `aria-pressed`](https://www.w3.org/TR/wai-aria-1.2/#aria-pressed).
 
 ```html
@@ -900,9 +903,9 @@ expected to return a normalized version of that string.
 
 > **Note**
 >
-> Specifying a value for `normalizer` _replaces_ the built-in normalization,
-> but you can call `getDefaultNormalizer` to obtain a built-in normalizer, either
-> to adjust that normalization or to call it from your own normalizer.
+> Specifying a value for `normalizer` _replaces_ the built-in normalization, but
+> you can call `getDefaultNormalizer` to obtain a built-in normalizer, either to
+> adjust that normalization or to call it from your own normalizer.
 
 `getDefaultNormalizer` takes an options object which allows the selection of
 behaviour:

--- a/docs/dom-testing-library/api-queries.md
+++ b/docs/dom-testing-library/api-queries.md
@@ -37,7 +37,9 @@ matches the given query. The promise is rejected if no element is found or if
 more than one element is found after a default timeout of `1000`ms. If you need
 to find more than one element, then use `findAllBy`.
 
-> Note, this is a simple combination of `getBy*` queries and
+> **Note**
+> 
+> this is a simple combination of `getBy*` queries and
 > [`waitFor`](/docs/api-async#waitfor). The `findBy*` queries accept the
 > `waitFor` options as the last argument. (i.e.
 > `screen.findByText('text', queryOptions, waitForOptions)`)
@@ -106,7 +108,9 @@ screen.debug(screen.getAllByText('multi-test'))
 
 ## Queries
 
-> NOTE: These queries are the base queries and require you pass a `container` as
+> **Note**
+>
+> These queries are the base queries and require you to pass a `container` as
 > the first argument. Most framework-implementations of Testing Library provide
 > a pre-bound version of these queries when you render your components with them
 > which means you do not have to provide a container. In addition, if you just
@@ -220,8 +224,11 @@ If it is important that you query an actual `<label>` element you can provide a
 const inputNode = screen.getByLabelText('Username', { selector: 'input' })
 ```
 
-Note that it will not work in the case where a `for` attr on a `label` matches
-and `id` field on a non-form element.
+> **Note** 
+>
+> `getByLabelText` will not work in the case where a `for` attr on a `<label>` 
+> element matches and `id` field on a non-form element.
+
 
 ```js
 // This case is not valid
@@ -719,7 +726,9 @@ you can get the "Sugar" option by calling
 state and which elements can have this state see
 [ARIA `aria-checked`](https://www.w3.org/TR/wai-aria-1.2/#aria-checked).
 
-> **Note:** Checkboxes have a "mixed" state, which is considered neither checked
+> **Note**
+> 
+> Checkboxes have a "mixed" state, which is considered neither checked
 > nor unchecked (details
 > [here](https://www.w3.org/TR/html-aam-1.0/#details-id-56)).
 
@@ -889,9 +898,11 @@ If you want to prevent that normalization, or provide alternative normalization
 function in the options object. This function will be given a string and is
 expected to return a normalized version of that string.
 
-Note: Specifying a value for `normalizer` _replaces_ the built-in normalization,
-but you can call `getDefaultNormalizer` to obtain a built-in normalizer, either
-to adjust that normalization or to call it from your own normalizer.
+> **Note**
+>
+> Specifying a value for `normalizer` _replaces_ the built-in normalization,
+> but you can call `getDefaultNormalizer` to obtain a built-in normalizer, either
+> to adjust that normalization or to call it from your own normalizer.
 
 `getDefaultNormalizer` takes an options object which allows the selection of
 behaviour:

--- a/docs/svelte-testing-library/setup.md
+++ b/docs/svelte-testing-library/setup.md
@@ -76,8 +76,7 @@ with any testing framework and runner you're comfortable with.
 
 To use Typescript, you'll need to install and configure `svelte-preprocess` and
 `ts-jest`. For full instructions, see the
-[`svelte-jester`](https://github.com/mihar-22/svelte-jester#typescript)
-docs.
+[`svelte-jester`](https://github.com/mihar-22/svelte-jester#typescript) docs.
 
 ## Babel / Preprocessors
 


### PR DESCRIPTION
I noticed there was a small typo (imo) when I was reading  "...will not work in the case where a `for` attr on a label matches and `id` field on a non-form element." and made some changes. 

I've highlighted the text changes in comments as unfortunately the diffs from the changes I made to the "Note" blocks make them hard to immediately spot.

I also took this opportunity to make the "Note" blocks within the page to be consistent with each other. 
The format was based off of this commit I found previously: https://github.com/testing-library/testing-library-docs/commit/5bab9829e25b8c962ffa2ca006b4893c4421762a

i.e. 
![Screen Shot 2020-08-18 at 08 58 42](https://user-images.githubusercontent.com/11592023/90536588-1890a080-e131-11ea-9a6b-925e23043d9b.png)


Please let me know if I've missed anything! I also ran `format-docs` just to make sure my changes stayed formatted properly - so there were also a few extra `md` files that were also updated.