### PR TITLE
Add which-query extension to documentation

### DIFF
--- a/docs/guide-which-query.md
+++ b/docs/guide-which-query.md
@@ -57,6 +57,10 @@ const { container } = render(<MyComponent />)
 const foo = container.querySelector('[data-foo="bar"]')
 ```
 
+## Chrome extension
+Do you still have problems knowing how to use Testing Library queries? 
+We got your back by creating a cool Chrome extension named [which-query](https://github.com/testing-library/which-query) that you can download [from here](https://chrome.google.com/webstore/detail/testing-library-which-que/olmmagdolfehlpjmbkmondggbebeimoh), and it aims to enable developers to find a better query when writing tests. Right click on an element on any web page and it will copy the best possible query for that element into your clipboard. Then simply paste into your test code. That also helps you to learn how to use React Testing Library queries.
+
 ## Playground
 
 If you want to get more familiar with these queries, you can try them out on


### PR DESCRIPTION
People come across the query page in the documentation, and they might not truly understand how to use `getByRole` or any other methods since they don't use to do that! 

They used to get an element by `class` name or `id` most of the time. Or they were simply using JQuery for many years. 

As a result, RTL's queries do not sound very familiar to them. The "which-query" chrome extension is a good place to help them get started. They can use it to learn how to access any element in the page, just by the help of RTL queries (instead of setting `data-testid`, ...)