### PR TITLE
Jasmine dom docs

### DIFF
--- a/docs/ecosystem-jasmine-dom.md
+++ b/docs/ecosystem-jasmine-dom.md
@@ -3,7 +3,7 @@ id: ecosystem-jasmine-dom
 title: jasmine-dom
 ---
 
-[`jasmine-dom`][gh] is a companion library for `React Testing Library` that
+[`jasmine-dom`][gh] is a companion library for Testing Library that
 provides custom DOM element matchers for Jasmine
 
 ```

--- a/docs/ecosystem-jasmine-dom.md
+++ b/docs/ecosystem-jasmine-dom.md
@@ -17,8 +17,8 @@ the matchers to Jasmine.
 <span data-testid="not-empty"><span data-testid="empty"></span></span>
 <div data-testid="visible">Visible Example</div>
 
-expect(queryByTestId(container, 'not-empty')).not.toBeEmptyDOMElement()
-expect(getByText(container, 'Visible Example')).toBeVisible()
+expect(screen.queryByTestId('not-empty')).not.toBeEmptyDOMElement()
+expect(screen.getByText('Visible Example')).toBeVisible()
 ```
 
 > Note: when using some of these matchers, you may need to make sure you use a

--- a/docs/ecosystem-jasmine-dom.md
+++ b/docs/ecosystem-jasmine-dom.md
@@ -1,0 +1,35 @@
+---
+id: ecosystem-jasmine-dom
+title: jasmine-dom
+---
+
+[`jasmine-dom`][gh] is a companion library for `React Testing Library` that
+provides custom DOM element matchers for Jasmine
+
+```
+npm install --save-dev @testing-library/jasmine-dom
+```
+
+Then follow [usage section][gh-usage] from jasmine-dom's documentation to add
+the matchers to Jasmine.
+
+```jsx
+<span data-testid="not-empty"><span data-testid="empty"></span></span>
+<div data-testid="visible">Visible Example</div>
+
+expect(queryByTestId(container, 'not-empty')).not.toBeEmptyDOMElement()
+expect(getByText(container, 'Visible Example')).toBeVisible()
+```
+
+> Note: when using some of these matchers, you may need to make sure you use a
+> query function (like `queryByTestId`) rather than a get function (like
+> `getByTestId`). Otherwise the `get*` function could throw an error before your
+> assertion.
+
+Check out [jasmine-dom's documentation][gh] for a full list of available
+matchers.
+
+- [jasmine-dom on GitHub][gh]
+
+[gh]: https://github.com/testing-library/jasmine-dom
+[gh-usage]: https://github.com/testing-library/jasmine-dom#usage

--- a/docs/ecosystem-jest-dom.md
+++ b/docs/ecosystem-jest-dom.md
@@ -17,7 +17,7 @@ matchers to Jest.
 <span data-testid="not-empty"><span data-testid="empty"></span></span>
 <div data-testid="visible">Visible Example</div>
 
-expect(queryByTestId(container, 'not-empty')).not.toBeEmpty()
+expect(queryByTestId(container, 'not-empty')).not.toBeEmptyDOMElement()
 expect(getByText(container, 'Visible Example')).toBeVisible()
 ```
 

--- a/docs/ecosystem-jest-dom.md
+++ b/docs/ecosystem-jest-dom.md
@@ -17,8 +17,8 @@ matchers to Jest.
 <span data-testid="not-empty"><span data-testid="empty"></span></span>
 <div data-testid="visible">Visible Example</div>
 
-expect(queryByTestId(container, 'not-empty')).not.toBeEmptyDOMElement()
-expect(getByText(container, 'Visible Example')).toBeVisible()
+expect(screen.queryByTestId('not-empty')).not.toBeEmptyDOMElement()
+expect(screen.getByText('Visible Example')).toBeVisible()
 ```
 
 > Note: when using some of these matchers, you may need to make sure you use a

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -112,7 +112,8 @@
       "ecosystem-react-select-event",
       "ecosystem-eslint-plugin-testing-library",
       "ecosystem-eslint-plugin-jest-dom",
-      "ecosystem-riot-testing-library"
+      "ecosystem-riot-testing-library",
+      "ecosystem-jasmine-dom"
     ],
     "Help": ["faq", "learning", "contributing"]
   },


### PR DESCRIPTION
There is a minor fix on jest-dom's docs, where instead of suggesting the use of toBeEmpty (deprecated in favor of toBeEmptyDOMElement) I changed it to promote the use of toBeEmptyDOMElement.

Other than that, I added a similar docs page for jasmine-dom 🙂