### PR TITLE
Rename `timeout` to `asyncUtilTimeout`

### DIFF
--- a/docs/dom-testing-library/api-configuration.md
+++ b/docs/dom-testing-library/api-configuration.md
@@ -58,7 +58,7 @@ the error message and container object as arguments.
 [`getBy*`](api-queries#getby) or [`getAllBy*`](api-queries#getallby) fail. Takes
 the error message and container object as arguments.
 
-`timeout`: The global timeout value in milliseconds used by `waitFor` utilities.
+`asyncUtilTimeout`: The global timeout value in milliseconds used by `waitFor` utilities.
 Defaults to 1000ms.
 
 <!--DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
Use the actual name for timeout configuration parameter.