### PR TITLE
Documentation: Fix typo and remove duplicate

### DIFF
--- a/docs/dom-testing-library/api-configuration.md
+++ b/docs/dom-testing-library/api-configuration.md
@@ -18,7 +18,7 @@ Configuration options:
 `computedStyleSupportsPseudoElements`: Set to `true` if
 `window.getComputedStyle` supports pseudo-elements i.e. a second argument. If
 you're using testing-library in a browser you almost always want to set this to
-`true`. Only very old browser don't support his property (such as IE 8 and
+`true`. Only very old browser don't support this property (such as IE 8 and
 earlier). However, `jsdom` does not support the second argument currently. This
 includes versions of `jsdom` prior to `16.4.0` and any version that logs a
 `not implemented` warning when calling `getComputedStyle` with a second argument
@@ -49,10 +49,6 @@ screen.getByTestId('foo', { suggest: false }) // will not throw a suggestion
 
 `testIdAttribute`: The attribute used by [`getByTestId`](api-queries#bytestid)
 and related queries. Defaults to `data-testid`.
-
-`getElementError`: A function that returns the error used when
-[`getBy*`](api-queries#getby) or [`getAllBy*`](api-queries#getallby) fail. Takes
-the error message and container object as arguments.
 
 `getElementError`: A function that returns the error used when
 [`getBy*`](api-queries#getby) or [`getAllBy*`](api-queries#getallby) fail. Takes


### PR DESCRIPTION
`getElementError` was duplicated.