### PR TITLE
Documentation: Update async section of cheatsheet

### DIFF
--- a/docs/dom-testing-library/cheatsheet.md
+++ b/docs/dom-testing-library/cheatsheet.md
@@ -79,13 +79,8 @@ See [Which query should I use?](guide-which-query.md)
 
 See [Async API](dom-testing-library/api-async.md)
 
-- **wait** (Promise) retry the function within until it stops throwing or times
+- **waitFor** (Promise) retry the function within until it stops throwing or times
   out
-- **waitForElement** (Promise) retry the function until it returns an element or
-  an array of elements
-  - `findBy` and `findAllBy` queries are async and retry until either a timeout
-    or if the query returns successfully; they wrap `waitForElement`
-- **waitForDomChange** (Promise) retry the function each time the DOM is changed
 - **waitForElementToBeRemoved** (Promise) retry the function until it no longer
   returns a DOM node
 

--- a/docs/dom-testing-library/cheatsheet.md
+++ b/docs/dom-testing-library/cheatsheet.md
@@ -77,16 +77,15 @@ See [Which query should I use?](guide-which-query.md)
 
 ## Async
 
-See [Async API](dom-testing-library/api-async.md)
+See [Async API](dom-testing-library/api-async.md). Remember to `await` or `.then()`
+the result of async functions in your tests!
 
 - **waitFor** (Promise) retry the function within until it stops throwing or times
   out
 - **waitForElementToBeRemoved** (Promise) retry the function until it no longer
   returns a DOM node
 
-> Remember to `await` or `.then()` the result of async functions in your tests!
-
-> Deprecated since v7.0.0
+> **Deprecated since v7.0.0:**
 > - **wait** (Promise) retry the function within until it stops throwing or times
 > - **waitForElement** (Promise) retry the function until it returns an element or
 >  an array of elements

--- a/docs/dom-testing-library/cheatsheet.md
+++ b/docs/dom-testing-library/cheatsheet.md
@@ -86,6 +86,14 @@ See [Async API](dom-testing-library/api-async.md)
 
 > Remember to `await` or `.then()` the result of async functions in your tests!
 
+> Deprecated since v7.0.0
+> - **wait** (Promise) retry the function within until it stops throwing or times
+> - **waitForElement** (Promise) retry the function until it returns an element or
+>  an array of elements
+>  - `findBy` and `findAllBy` queries are async and retry until either a timeout
+>    or if the query returns successfully; they wrap `waitForElement`
+> - **waitForDomChange** (Promise) retry the function each time the DOM is changed
+
 ## Events
 
 See [Considerations for fireEvent](guide-events.md), [Events API](api-events.md)

--- a/docs/react-testing-library/cheatsheet.md
+++ b/docs/react-testing-library/cheatsheet.md
@@ -108,13 +108,8 @@ See [Which query should I use?](guide-which-query.md)
 
 See [dom-testing-library Async API](dom-testing-library/api-async.md)
 
-- **wait** (Promise) retry the function within until it stops throwing or times
+- **waitFor** (Promise) retry the function within until it stops throwing or times
   out
-- **waitForElement** (Promise) retry the function until it returns an element or
-  an array of elements
-  - `findBy` and `findAllBy` queries are async and retry until either a timeout
-    or if the query returns successfully; they wrap `waitForElement`
-- **waitForDomChange** (Promise) retry the function each time the DOM is changed
 - **waitForElementToBeRemoved** (Promise) retry the function until it no longer
   returns a DOM node
 

--- a/docs/react-testing-library/cheatsheet.md
+++ b/docs/react-testing-library/cheatsheet.md
@@ -109,6 +109,11 @@ See [Which query should I use?](guide-which-query.md)
 The [dom-testing-library Async API](dom-testing-library/api-async.md) is
 re-exported from React Testing Library.
 
+- **waitFor** (Promise) retry the function within until it stops throwing or
+  times out
+- **waitForElementToBeRemoved** (Promise) retry the function until it no longer
+  returns a DOM node
+
 ## Events
 
 See [Events API](dom-testing-library/api-events.md)

--- a/docs/react-testing-library/cheatsheet.md
+++ b/docs/react-testing-library/cheatsheet.md
@@ -108,12 +108,20 @@ See [Which query should I use?](guide-which-query.md)
 
 See [dom-testing-library Async API](dom-testing-library/api-async.md)
 
-- **waitFor** (Promise) retry the function within until it stops throwing or times
-  out
+- **waitFor** (Promise) retry the function within until it stops throwing or times out
 - **waitForElementToBeRemoved** (Promise) retry the function until it no longer
   returns a DOM node
 
 > Remember to `await` or `.then()` the result of async functions in your tests!
+  
+> Deprecated since v7.0.0
+> - **wait** (Promise) retry the function within until it stops throwing or times out
+> - **waitForElement** (Promise) retry the function until it returns an element or
+>  an array of elements
+>  - `findBy` and `findAllBy` queries are async and retry until either a timeout
+>    or if the query returns successfully; they wrap `waitForElement`
+> - **waitForDomChange** (Promise) retry the function each time the DOM is changed
+
 
 ## Events
 

--- a/docs/react-testing-library/cheatsheet.md
+++ b/docs/react-testing-library/cheatsheet.md
@@ -106,22 +106,8 @@ See [Which query should I use?](guide-which-query.md)
 
 ## Async
 
-See [dom-testing-library Async API](dom-testing-library/api-async.md)
-
-- **waitFor** (Promise) retry the function within until it stops throwing or times out
-- **waitForElementToBeRemoved** (Promise) retry the function until it no longer
-  returns a DOM node
-
-> Remember to `await` or `.then()` the result of async functions in your tests!
-  
-> Deprecated since v7.0.0
-> - **wait** (Promise) retry the function within until it stops throwing or times out
-> - **waitForElement** (Promise) retry the function until it returns an element or
->  an array of elements
->  - `findBy` and `findAllBy` queries are async and retry until either a timeout
->    or if the query returns successfully; they wrap `waitForElement`
-> - **waitForDomChange** (Promise) retry the function each time the DOM is changed
-
+The [dom-testing-library Async API](dom-testing-library/api-async.md) is
+re-exported from React Testing Library.
 
 ## Events
 


### PR DESCRIPTION
Remove  replace `wait` for `waitFor` and deprecated methods