### PR TITLE
remove dead link in examples for cypress testing library documentation

### DIFF
--- a/docs/cypress-testing-library/intro.md
+++ b/docs/cypress-testing-library/intro.md
@@ -52,7 +52,7 @@ You can find
 ## Examples
 
 To show some simple examples (from
-[cypress/integration/find.spec.js](https://github.com/testing-library/cypress-testing-library/blob/master/cypress/integration/find.spec.js)):
+[cypress/integration/find.spec.js](https://github.com/testing-library/cypress-testing-library/blob/97939da7d4707a71049884c0324c0eda56e26fc2/cypress/integration/find.spec.js)):
 
 ```javascript
 cy.findByRole('button', { name: /Jackie Chan/i }).click()

--- a/docs/cypress-testing-library/intro.md
+++ b/docs/cypress-testing-library/intro.md
@@ -51,10 +51,8 @@ You can find
 
 ## Examples
 
-To show some simple examples (from
-[cypress/integration/query.spec.js](https://github.com/testing-library/cypress-testing-library/blob/master/cypress/integration/query.spec.js)
-or
-[cypress/integration/find.spec.js](https://github.com/testing-library/cypress-testing-library/blob/master/cypress/integration/find.spec.js)):
+To show some simple examples
+([cypress/integration/find.spec.js](https://github.com/testing-library/cypress-testing-library/blob/master/cypress/integration/find.spec.js)):
 
 ```javascript
 cy.findByRole('button', { name: /Jackie Chan/i }).click()


### PR DESCRIPTION
Remove dead cypress testing library example link (file no longer exists)