### PR TITLE
Fix migrate from enzyme link in the sidebar

### DIFF
--- a/docs/react-testing-library/migrate-from-enzyme.md
+++ b/docs/react-testing-library/migrate-from-enzyme.md
@@ -1,5 +1,5 @@
 ---
-id: migrate
+id: migrate-from-enzyme
 title: Migrate from Enzyme
 sidebar_label: Migrate from Enzyme
 ---

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -27,7 +27,7 @@
           "react-testing-library/example-intro",
           "react-testing-library/setup",
           "react-testing-library/api",
-          "react-testing-library/migrate  ",
+          "react-testing-library/migrate",
           "react-testing-library/faq",
           "react-testing-library/cheatsheet"
         ]

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -27,7 +27,7 @@
           "react-testing-library/example-intro",
           "react-testing-library/setup",
           "react-testing-library/api",
-          "react-testing-library/migrate-from-enzyme",
+          "react-testing-library/migrate  ",
           "react-testing-library/faq",
           "react-testing-library/cheatsheet"
         ]

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -27,7 +27,7 @@
           "react-testing-library/example-intro",
           "react-testing-library/setup",
           "react-testing-library/api",
-          "react-testing-library/migrate",
+          "react-testing-library/migrate-from-enzyme",
           "react-testing-library/faq",
           "react-testing-library/cheatsheet"
         ]


### PR DESCRIPTION
In [this comment](https://github.com/testing-library/testing-library-docs/pull/568#issuecomment-689109044), @MatanBobi  said the issue with the "Migrate from Enzyme" page which is not showing in the sidebar would be resolved if we change its name in the sidebar (to be equal to the `id` which is defined in the `migrate-from-enzyme.md` )

