### PR TITLE
Fix TypeScript tsconfig.json instructions

### DIFF
--- a/docs/cypress-testing-library/intro.md
+++ b/docs/cypress-testing-library/intro.md
@@ -34,14 +34,12 @@ and `queryAllBy` commands off the global `cy` object.
 
 ## With TypeScript
 
-Typings are defined in `@types/testing-library__cypress` at
-[DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__cypress),
-and should be added as follows in `tsconfig.json`:
+Typings should be added as follows in `tsconfig.json`:
 
 ```json
 {
   "compilerOptions": {
-    "types": ["cypress", "@types/testing-library__cypress"]
+    "types": ["cypress", "@testing-library/cypress"]
   }
 }
 ```


### PR DESCRIPTION
Adapt instructions on how to add typings (typings are now directly managed in the npm package, instead of via DefinitelyTyped)