### PR TITLE
fix(redirects): redirect error message url to correct page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -145,3 +145,10 @@
   to = "https://redux.js.org/recipes/writing-tests#connected-components"
   status = 301
   force = true
+
+# Redirect screen error messe to correct page
+[[redirects]]
+  from = "https://testing-library.com/s/screen-global-error"
+  to = "https://testing-library.com/docs/dom-testing-library/api-queries#screen"
+  status = 301
+  force = true


### PR DESCRIPTION
As @eps1lon suggested in https://github.com/testing-library/dom-testing-library/pull/764.
At the moment when there's no document defined and we're trying to use `screen` there's an error message with a broken link.
This change is to add a redirect to the correct place if a user tries to enter the broken link.