### PR TITLE
Fix baseElement's default value in react docs

### DIFF
--- a/docs/react-testing-library/api.md
+++ b/docs/react-testing-library/api.md
@@ -70,7 +70,7 @@ const { container } = render(<TableBody {...props} />, {
 ### `baseElement`
 
 If the `container` is specified, then this defaults to that, otherwise this
-defaults to `document.documentElement`. This is used as the base element for the
+defaults to `document.body`. This is used as the base element for the
 queries as well as what is printed when you use `debug()`.
 
 ### `hydrate`


### PR DESCRIPTION
I changed the default value for `baseElement` in render options to be consistent with

- The default value of render result's `baseElement` (it's documented a little further down the page)
- What I'm seeing in my usage of RTL 11.0.2