### PR TITLE
docs: Fix update event link in Vue cheatsheet

### DIFF
--- a/docs/vue-testing-library/cheatsheet.md
+++ b/docs/vue-testing-library/cheatsheet.md
@@ -81,7 +81,7 @@ For more information, see [Events API](dom-testing-library/api-events.md)
 > `await` or `then()` the result.
 >
 > VTL also exposes `fireEvent.update(node, value)` event to deal with `v-model`.
-> See [the API](vue-testing-library/api#updateelem-value) for more details.
+> See [the API](vue-testing-library/api.md#updateelem-value) for more details.
 
 ## Other
 


### PR DESCRIPTION
Tiny pull request to fix a broken link to the API page `update` section in the Vue cheatsheet.

All the best!