### PR TITLE
docs: fix typo in api async docs

### DIFF
--- a/docs/dom-testing-library/api-async.md
+++ b/docs/dom-testing-library/api-async.md
@@ -40,7 +40,7 @@ await waitFor(() => expect(mockAPI).toHaveBeenCalledTimes(1))
 This can be useful if you have a unit test that mocks API calls and you need to
 wait for your mock promises to all resolve.
 
-If you return a promise in the `waitFor` callback (either explicitely or
+If you return a promise in the `waitFor` callback (either explicitly or
 implicitly with `async` syntax), then the `waitFor` utility will not call your
 callback again until that promise rejects. This allows you to `waitFor` things
 that must be checked asynchronously.


### PR DESCRIPTION
@kentcdodds I noticed you've just updated the `api-async` docs with documentation on Promise support with `waitFor` but there was a typo introduced 😅  - this PR fixes that typo! 