### PR TITLE
docs(user-event): add known limitations section

### DIFF
--- a/docs/ecosystem-user-event.md
+++ b/docs/ecosystem-user-event.md
@@ -28,3 +28,8 @@ test('types inside textarea', () => {
 [gh]: https://github.com/testing-library/user-event
 [docs]:
   https://testing-library.com/docs/dom-testing-library/api-events#fireevent
+
+## Known limitations
+
+- No `<input type="color" />` support.
+  [#423](https://github.com/testing-library/user-event/issues/423#issuecomment-669368863)

--- a/docs/ecosystem-user-event.md
+++ b/docs/ecosystem-user-event.md
@@ -25,11 +25,11 @@ test('types inside textarea', () => {
 
 - [user-event on GitHub][gh]
 
-[gh]: https://github.com/testing-library/user-event
-[docs]:
-  https://testing-library.com/docs/dom-testing-library/api-events#fireevent
-
 ## Known limitations
 
 - No `<input type="color" />` support.
   [#423](https://github.com/testing-library/user-event/issues/423#issuecomment-669368863)
+
+[gh]: https://github.com/testing-library/user-event
+[docs]:
+  https://testing-library.com/docs/dom-testing-library/api-events#fireevent


### PR DESCRIPTION
Hey @kentcdodds as explained in [this comment](https://github.com/testing-library/user-event/issues/423#issuecomment-669368863) simulating this in the DOM would be quite tricky, so this PR is to add a `Known limitations` section to the `user-event` referencing the issue.