### PR TITLE
docs: update `waitForElementToBeRemoved`

### DIFF
--- a/docs/dom-testing-library/api-async.md
+++ b/docs/dom-testing-library/api-async.md
@@ -83,8 +83,12 @@ To wait for the removal of element(s) from the DOM you can use
 `waitForElementToBeRemoved`. The `waitForElementToBeRemoved` function is a small
 wrapper around the `waitFor` utility.
 
-The first argument must be an element, array of elements, or a callback which
-returns an element or array of elements.
+The first argument must be a callback which returns an element or array of
+elements, an element, or an array of elements. The recommended approach is to
+use a callback that returns an element or array of elements. This is because DOM
+nodes aren't guaranteed to be removed but rather updated in frameworks such as
+React. This could lead to unexpected results when passing an element or array of
+elements as the element is not actually removed, but instead updated.
 
 Here is an example where the promise resolves because the element is removed:
 


### PR DESCRIPTION
I've added clarification that a callback function is the recommended argument type to be passed into the `callback` argument of `waitForElementToBeRemoved`. As DOM nodes are not guaranteed to be removed in frameworks such as React; They may be updated rather than removed as referenced in issue #409.

I'd like to add a vanilla JS example in the following `md` file, but I'm not sure how to replicate the issue that was described in the issue thread, and I'd appreciate any assistance with getting some working examples to add to the docs!

I have a sandbox up here with a Vanilla JS example [here](https://codesandbox.io/s/proud-haze-8k7c9?file=/src/index.test.js), but I'm not sure how to test the text change (AFAIK - it should work as expected, it's
essentially the same logic as the React example).

I also have a React example [here](https://codesandbox.io/s/async-cookies-oieh1?file=/src/App.test.js), where I was trying to reproduce the failing case that @kentcdodds reported [here](https://github.com/testing-library/testing-library-docs/issues/409#issuecomment-601957917) in order to add an example of the failure that was mentioned. 

The second test case is where I pass an element directly instead of a callback, but it seems like this case passes 🤔 

