### PR TITLE
fix: missing repository url in help page

### DIFF
--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -46,7 +46,7 @@ export default function Help(props) {
       title: 'Resources',
     },
     {
-      content: `Get support on [GitHub](${props.config.repoUrl})`,
+      content: `Get support on [GitHub](${siteConfig.customFields.repoUrl})`,
       title: 'GitHub',
     },
   ]


### PR DESCRIPTION
Fixes #664 

Might have been caused by a Docosaurus update?