### PR TITLE
fix: broken user-event link on the page

### DIFF
--- a/docs/guide-events.mdx
+++ b/docs/guide-events.mdx
@@ -38,7 +38,7 @@ simply using `fireEvent.click` is worth it.
 We will describe a couple of simple adjustments to your tests that will increase
 your confidence in the interactive behavior of your components. For other
 interactions you may want to either consider using
-[`user-event`](https://testing-library.com/docs/ecosystem-user-event/) or testing your components in a real
+[`user-event`](ecosystem-user-event.mdx) or testing your components in a real
 environment (e.g. manually, automatic with cypress etc.).
 
 ### Keydown

--- a/docs/guide-events.mdx
+++ b/docs/guide-events.mdx
@@ -38,7 +38,7 @@ simply using `fireEvent.click` is worth it.
 We will describe a couple of simple adjustments to your tests that will increase
 your confidence in the interactive behavior of your components. For other
 interactions you may want to either consider using
-[`user-event`](ecosystem-user-event) or testing your components in a real
+[`user-event`](https://testing-library.com/docs/ecosystem-user-event/) or testing your components in a real
 environment (e.g. manually, automatic with cypress etc.).
 
 ### Keydown


### PR DESCRIPTION
Tried using [gh] but I wasn't able to get the desired effects in the Github previewer so I fell-back to this option. Please let me know what the best option is to fix this.