### PR TITLE
docs: remove notes about some polyfills

### DIFF
--- a/docs/dom-testing-library/setup.mdx
+++ b/docs/dom-testing-library/setup.mdx
@@ -32,7 +32,3 @@ With mocha, the test command would look something like this:
 ```
 mocha --require jsdom-global/register
 ```
-
-> Note, depending on the version of Node you're running, you may also need to
-> add `core-js` and `regenerator-runtime` (if you're using babel 7) or
-> `babel-polyfill` (for babel 6).

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -97,8 +97,8 @@ module.exports = {
 
 You can define your own custom queries as described in the example in the
 [Helpers API](dom-testing-library/api-helpers.mdx) documentation, or via the
-[`buildQueries`](dom-testing-library/api-helpers.mdx#buildqueries) helper.
-Then you can use them in any render call using the `queries` option. To make the
+[`buildQueries`](dom-testing-library/api-helpers.mdx#buildqueries) helper. Then
+you can use them in any render call using the `queries` option. To make the
 custom queries available globally, you can add them to your custom render method
 as shown below.
 
@@ -281,16 +281,12 @@ With mocha, the test command would look something like this:
 mocha --require jsdom-global/register
 ```
 
-Note, depending on the version of Node you're running, you may also need to
-install @babel/polyfill (if you're using babel 7) or babel-polyfill (for babel
-6).
-
 ### Skipping Auto Cleanup
 
-[`Cleanup`](api.mdx#cleanup) is called after each test automatically by default if
-the testing framework you're using supports the `afterEach` global (like mocha,
-Jest, and Jasmine). However, you may choose to skip the auto cleanup by setting
-the `RTL_SKIP_AUTO_CLEANUP` env variable to 'true'. You can do this with
+[`Cleanup`](api.mdx#cleanup) is called after each test automatically by default
+if the testing framework you're using supports the `afterEach` global (like
+mocha, Jest, and Jasmine). However, you may choose to skip the auto cleanup by
+setting the `RTL_SKIP_AUTO_CLEANUP` env variable to 'true'. You can do this with
 [`cross-env`](https://github.com/kentcdodds/cross-env) like so:
 
 ```


### PR DESCRIPTION
We mention some polyfills that don't seem to be necessary any more and could cause confusion when setting up libraries.

# Removed
- `core-js`: modern Node versions should already support most useful ES features, and common setups like CRA already polyfill anything that isn't supported
- `regenerator-runtime`: this hasn't been needed since Node 6 which has lost support years ago
- `babel-polyfill` and `@babel/polyfill`: deprecated

# Not removed
- Babel 6 module fix for Jest: could still be an issue for older projects that haven't upgraded to Babel 7 yet
- pre-Node 13 `full-icu`: some LTS releases of Node are older than 13 so this is still important to support