### PR TITLE
Explain Why VTL Uses async fireEvent Functions

### DIFF
--- a/docs/vue-testing-library/api.mdx
+++ b/docs/vue-testing-library/api.mdx
@@ -188,9 +188,10 @@ It returns a Promise through `wait()`, so you can `await updateProps(...)`.
 
 ## `fireEvent`
 
-Vue Testing Library re-exports all DOM Testing Library
-[firing events](dom-testing-library/api-events.mdx).
-However, it alters them so that all events are async.
+Because Vue applies DOM updates asynchronously during re-renders, the
+[fireEvent](dom-testing-library/api-events.mdx) tools are re-exported as `async`
+functions. To ensure that the DOM is properly updated in response to an event in
+a test, it's recommended to always `await` `fireEvent`.
 
 ```js
 await fireEvent.click(getByText('Click me'))


### PR DESCRIPTION
Adding this in the hopes of clarifying why VTL uses async fireEvent without overwhelming the user with unnecessary details.