### PR TITLE
Update example-formik.md

### DIFF
--- a/docs/example-formik.md
+++ b/docs/example-formik.md
@@ -75,7 +75,7 @@ test('rendering and submiting a basic Formik form', async () => {
       email: 'jhon.dee@someemail.com',
       firstName: 'Jhon',
       lastName: 'Dee',
-    })
+    }, expect.anything())
   )
 })
 ```


### PR DESCRIPTION
onSubmit has two arguments and we need to ignore the second one. (https://formik.org/docs/api/formik#onsubmit-values-values-formikbag-formikbag--void--promiseany)
If we do not do this then we will get an error: 
```
expect(jest.fn()).toHaveBeenCalledWith(...expected)

    - Expected
    + Received

      {"email": "email@example.com", "password": "password2398"},
    + {"resetForm": [Function anonymous], "setErrors": [Function anonymous], "setFieldError": [Function anonymous], "setFieldTouched": [Function anonymous], "setFieldValue": [Function anonymous], "setFormikState": [Function anonymous], "setStatus": [Function anonymous], "setSubmitting": [Function anonymous], "setTouched": [Function anonymous], "setValues": [Function anonymous], "submitForm": [Function anonymous], "validateField": [Function anonymous], "validateForm": [Function anonymous]},
```