### PR TITLE
Make date format clearer to understand

### DIFF
--- a/docs/dom-testing-library/api-events.mdx
+++ b/docs/dom-testing-library/api-events.mdx
@@ -70,10 +70,10 @@ fireEvent.change(getByLabelText(/picture/i), {
 // reflect the changed value.
 
 // Invalid:
-fireEvent.change(input, { target: { value: '12/05/2020' } })
+fireEvent.change(input, { target: { value: '24/05/2020' } })
 
 // Valid:
-fireEvent.change(input, { target: { value: '2020-05-12' } })
+fireEvent.change(input, { target: { value: '2020-05-24' } })
 ```
 
 **dataTransfer**: Drag events have a `dataTransfer` property that contains data


### PR DESCRIPTION
While it was specified that the date value should follow the ISO 8601 format, this change makes it much clearer for the reader to instantly tell what the ISO 8601 format is without opening another tab to check, just like I did while reading the doc. By using "24" instead of "12", it makes it clear that that portion of the format is referring to the day and not month since there's no 24th month in a calendar year