### PR TITLE
vue: Clarify what the return value of the callback param does in `render`

### DIFF
--- a/docs/vue-testing-library/api.mdx
+++ b/docs/vue-testing-library/api.mdx
@@ -81,9 +81,8 @@ Router.
 function callbackFunction(vueInstance, vuexStore, router) {}
 ```
 
-A callback function that receives the Vue instance as a parameter. Its return value passes additional options to `@vue/test-utils`
-[mount](https://vue-test-utils.vuejs.org/api/options.html#context). This allows
-3rd party plugins to be installed prior to mount.
+A callback function that receives the Vue instance as a parameter. Its return value is merged with [options](#options), allowing
+3rd party plugins to be installed prior to mount. To see how this works, see the example using [`vue-i18n`](https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vue-i18n.js).
 
 The function will also receive the Store or the Router object if the associated
 option was passed in during render.

--- a/docs/vue-testing-library/api.mdx
+++ b/docs/vue-testing-library/api.mdx
@@ -81,7 +81,8 @@ Router.
 function callbackFunction(vueInstance, vuexStore, router) {}
 ```
 
-A callback function that receives the Vue instance as a parameter. This allows
+A callback function that receives the Vue instance as a parameter. Its return value passes additional options to `@vue/test-utils`
+[mount](https://vue-test-utils.vuejs.org/api/options.html#context). This allows
 3rd party plugins to be installed prior to mount.
 
 The function will also receive the Store or the Router object if the associated


### PR DESCRIPTION
I'm currently learning vue-testing-library and had some trouble trying to set up `vuex` instance with [`simple-vuex`](https://github.com/sascha245/vuex-simple). I found out elsewhere that a possible way to do this would be to use the callback parameter to return a store like the below 
```tsx
const store = createVuexStore(new RootStore())

// doesn't work because `createVuexStore(new RootStore())` is already an instance of `Vuex.Store`
render(MyComponent, {props: {happy: true}, store})

render(MyComponent, {props: {happy: true}}, () => ({ store }))
```

I think I could have noticed this sooner if the documentation described this line in the code: https://github.com/testing-library/vue-testing-library/blob/2312e180b12df3c599e8aa8a0ee85dcff7b108e7/src/vue-testing-library.js#L52. This is what i have tried to do in my proposed change above.