### PR TITLE
docs: Explicitly mention what is thrown

### DIFF
--- a/docs/dom-testing-library/api-queries.mdx
+++ b/docs/dom-testing-library/api-queries.mdx
@@ -26,7 +26,7 @@ an error if no elements match.
 
 `queryBy*` queries return the first matching node for a query, and return `null`
 if no elements match. This is useful for asserting an element that is not
-present. This throws if more than one match is found (use `queryAllBy` instead).
+present. This throws an error if more than one match is found (use `queryAllBy` instead).
 
 ### queryAllBy
 


### PR DESCRIPTION
Just updating a sentence to make more sense.

From:
- _This throws_ if more than one match is found (use `queryAllBy` instead).

To: 
- _This throws an error_ if more than one match is found (use `queryAllBy` instead).
