### PR TITLE
docs: fix the cypress-testing-library types link

### DIFF
--- a/docs/cypress-testing-library/intro.mdx
+++ b/docs/cypress-testing-library/intro.mdx
@@ -45,7 +45,7 @@ Typings should be added as follows in `tsconfig.json`:
 ```
 
 You can find
-[all Library definitions here](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__cypress/index.d.ts).
+[all Library definitions here](https://github.com/testing-library/cypress-testing-library/blob/master/types/index.d.ts).
 
 ## Examples
 


### PR DESCRIPTION
The link should be updated since the types [moved](https://github.com/testing-library/cypress-testing-library/pull/148) from DefinitelyTyped into the repo.