### PR TITLE
docs: Update `getBy*` description

### DIFF
--- a/docs/dom-testing-library/api-queries.mdx
+++ b/docs/dom-testing-library/api-queries.mdx
@@ -13,9 +13,8 @@ import TabItem from '@theme/TabItem'
 
 ### getBy
 
-`getBy*` queries return the first matching node for a query, and throw an error
-if no elements match or if more than one match is found (use `getAllBy`
-instead).
+`getBy*` queries return the matching node for a query, and throw an error if no
+elements match or if more than one match is found (use `getAllBy` instead).
 
 ### getAllBy
 


### PR DESCRIPTION
### Why 
Updating this based on thread in [cypress-testing-library issue #146](https://github.com/testing-library/cypress-testing-library/issues/146#issuecomment-753345339)

&ast;By&ast; throws an error when there are more than one element, it is not immediately clear when reading [documentation](https://testing-library.com/docs/dom-testing-library/api-queries#getby) at a glance. 

