### PR TITLE
fix: Broken link to getByLabelText

### DIFF
--- a/docs/queries/bytext.mdx
+++ b/docs/queries/bytext.mdx
@@ -76,8 +76,8 @@ It also works with `input`s whose `type` attribute is either `submit` or
 
 > **Note**
 >
-> See [`getByLabelText`](#bylabeltext) for more details on how and when to use
-> the `selector` option
+> See [`getByLabelText`](bylabeltext#selector) for more details on how and when
+> to use the `selector` option
 
 ### `ignore`
 


### PR DESCRIPTION
Hello, I found a broken link while consulting the docs.

I made the patch through the github interface to try it out and haven't yet ran the actual site to make sure it's correct (will do later). I haven't seen any issue related to this one either, if you need one I can create it.

Cheers