### PR TITLE
updated `toHaveLength` example

### DIFF
--- a/docs/guide-disappearance.mdx
+++ b/docs/guide-disappearance.mdx
@@ -86,7 +86,7 @@ DOM.
 
 ```javascript
 const submitButtons = screen.queryAllByText('submit')
-expect(submitButtons).toHaveLength(2) // expect 2 elements
+expect(submitButtons).toHaveLength(0) // expect no elements
 ```
 
 ### `not.toBeInTheDocument`


### PR DESCRIPTION
updated `toHaveLength` example to avoid confusion:
The existing example asserts that two elements exist, and this can be a little confusing since the section is named "Asserting elements are not present"