### PR TITLE
docs: add periods at end of sentences

### DIFF
--- a/docs/dom-testing-library/api-accessibility.mdx
+++ b/docs/dom-testing-library/api-accessibility.mdx
@@ -61,7 +61,7 @@ function isInaccessible(element: Element): boolean
 This helper function can be used to print out a list of all the implicit ARIA
 roles within a tree of DOM nodes, each role containing a list of all of the
 nodes which match that role. This can be helpful for finding ways to query the
-DOM under test with [getByRole](queries/byrole.mdx)
+DOM under test with [getByRole](queries/byrole.mdx).
 
 ```javascript
 import { logRoles } from '@testing-library/dom'

--- a/docs/dom-testing-library/api-debugging.mdx
+++ b/docs/dom-testing-library/api-debugging.mdx
@@ -38,7 +38,7 @@ DEBUG_PRINT_LIMIT=10000 npm test
 
 This works on macOS/Linux, you'll need to do something else for Windows. If
 you'd like a solution that works for both, see
-[`cross-env`](https://www.npmjs.com/package/cross-env)
+[`cross-env`](https://www.npmjs.com/package/cross-env).
 
 ## `prettyDOM`
 
@@ -83,7 +83,7 @@ This function is what also powers
 This helper function can be used to print out a list of all the implicit ARIA
 roles within a tree of DOM nodes, each role containing a list of all of the
 nodes which match that role. This can be helpful for finding ways to query the
-DOM under test with [getByRole](queries/byrole.mdx)
+DOM under test with [getByRole](queries/byrole.mdx).
 
 ```javascript
 import { logRoles } from '@testing-library/dom'


### PR DESCRIPTION
Add periods at end of sentences in _Advanced > Accessibility_ and _Advanced > Debugging_ sections.