### PR TITLE
docs: minor typos

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -97,8 +97,8 @@ Based on [the Guiding Principles](guiding-principles.mdx), your test should
 resemble how users interact with your code (component, page, etc.) as much as
 possible. With this in mind, we recommend this order of priority:
 
-1. **Queries Accessible to Everyone** queries that reflect the experience of
-   visual/mouse users as well as those that use assistive technology
+1. **Queries Accessible to Everyone** Queries that reflect the experience of
+   visual/mouse users as well as those that use assistive technology.
    1. `getByRole`: This can be used to query every element that is exposed in
       the
       [accessibility tree](https://developer.mozilla.org/en-US/docs/Glossary/AOM).
@@ -110,13 +110,14 @@ possible. With this in mind, we recommend this order of priority:
       `getByRole('button', {name: /submit/i})`. Check the
       [list of roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#Roles).
    1. `getByLabelText`: Only really good for form fields, but this is the number
-      one method a user finds those elements, so it should be your top
-      preference.
+      one method to make sure that a user finds those elements, so it should be
+      your top preference.
    1. `getByPlaceholderText`:
       [A placeholder is not a substitute for a label](https://www.nngroup.com/articles/form-design-placeholders/).
       But if that's all you have, then it's better than alternatives.
-   1. `getByText`: Not useful for forms, but this is the number 1 method a user
-      finds most non-interactive elements (like divs and spans).
+   1. `getByText`: Not useful for forms, but this is the number one method to
+      make sure that a user finds most non-interactive elements (like `div`s and
+      `span`s).
    1. `getByDisplayValue`: The current value of a form element can be useful
       when navigating a page with filled-in values.
 1. **Semantic Queries** HTML5 and ARIA compliant selectors. Note that the user

--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -109,15 +109,15 @@ possible. With this in mind, we recommend this order of priority:
       often, this will be used with the `name` option like so:
       `getByRole('button', {name: /submit/i})`. Check the
       [list of roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#Roles).
-   1. `getByLabelText`: Only really good for form fields, but this is the number
-      one method to make sure that a user finds those elements, so it should be
-      your top preference.
+   1. `getByLabelText`: This method is really good for form fields. When
+      navigating through a website form, users find elements using label text.
+      This method emulates that behavior, so it should be your top preference.
    1. `getByPlaceholderText`:
       [A placeholder is not a substitute for a label](https://www.nngroup.com/articles/form-design-placeholders/).
       But if that's all you have, then it's better than alternatives.
-   1. `getByText`: Not useful for forms, but this is the number one method to
-      make sure that a user finds most non-interactive elements (like `div`s and
-      `span`s).
+   1. `getByText`: Outside of forms, text content is the main way users find
+      elements. This method can be used to find non-interactive elements (like
+      divs, spans, and paragraphs).
    1. `getByDisplayValue`: The current value of a form element can be useful
       when navigating a page with filled-in values.
 1. **Semantic Queries** HTML5 and ARIA compliant selectors. Note that the user


### PR DESCRIPTION
Assuming by `users` we meant the end-user that will be using the software where testing is implemented and `method` here refers to JS method/function, I have updated two sentences.

Other Minor changes:
1. Capitalize **Queries**.
2. Full stop at the end of a sentence.
3. Changed 1(numeric) to one(text) to stay consistent.
4. Code-highlighted `div` and `span` as in the next point other HTML elements like `img`, `input`, etc were also highlighted.

