### PR TITLE
Fix typo in example-formik.md

### DIFF
--- a/docs/example-formik.md
+++ b/docs/example-formik.md
@@ -60,20 +60,20 @@ import userEvent from '@testing-library/user-event'
 
 import { MyForm } from './myForm.js'
 
-test('rendering and submiting a basic Formik form', async () => {
+test('rendering and submitting a basic Formik form', async () => {
   const handleSubmit = jest.fn()
   render(<MyForm onSubmit={handleSubmit} />)
 
-  userEvent.type(screen.getByLabelText(/first name/i), 'Jhon')
+  userEvent.type(screen.getByLabelText(/first name/i), 'John')
   userEvent.type(screen.getByLabelText(/last name/i), 'Dee')
-  userEvent.type(screen.getByLabelText(/email/i), 'jhon.dee@someemail.com')
+  userEvent.type(screen.getByLabelText(/email/i), 'john.dee@someemail.com')
 
   userEvent.click(screen.getByRole('button', { name: /submit/i }))
 
   await waitFor(() =>
     expect(handleSubmit).toHaveBeenCalledWith({
-      email: 'jhon.dee@someemail.com',
-      firstName: 'Jhon',
+      email: 'john.dee@someemail.com',
+      firstName: 'John',
       lastName: 'Dee',
     }, expect.anything())
   )


### PR DESCRIPTION
Fixing a typo within the example-formik[ markdown](https://testing-library.com/docs/example-react-formik/).

`submiting` -> `submitting`
`jhon` -> `john`