### PR TITLE
Fix typo in title of byplaceholdertext

### DIFF
--- a/docs/queries/byplaceholdertext.mdx
+++ b/docs/queries/byplaceholdertext.mdx
@@ -1,6 +1,6 @@
 ---
 id: byplaceholdertext
-title: ByPlaceHolderText
+title: ByPlaceholderText
 ---
 
 import Tabs from '@theme/Tabs'


### PR DESCRIPTION
This PR fixes a typo in page title for https://testing-library.com/docs/queries/byplaceholdertext