### PR TITLE
Replace jsdom-global with global-jsdom

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -294,19 +294,19 @@ configuration with Jest).
 `jsdom` is a pure JavaScript implementation of the DOM and browser APIs that
 runs in Node. If you're not using Jest and you would like to run your tests in
 Node, then you must install jsdom yourself. There's also a package called
-`jsdom-global` which can be used to setup the global environment to simulate the
+`global-jsdom` which can be used to setup the global environment to simulate the
 browser APIs.
 
-First, install `jsdom` and `jsdom-global`.
+First, install `jsdom` and `global-jsdom`.
 
 ```
-npm install --save-dev jsdom jsdom-global
+npm install --save-dev jsdom global-jsdom
 ```
 
 With mocha, the test command would look something like this:
 
 ```
-mocha --require jsdom-global/register
+mocha --require global-jsdom/register
 ```
 
 ### Skipping Auto Cleanup


### PR DESCRIPTION
When trying to use `jsdom-global` with React tests, you will see these warnings in the console:

```
This browser doesn't support requestAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills
This browser doesn't support cancelAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills
```

This package does not expose these functions. However, there is a modern fork, `global-jsdom` which offers the same API, but also exports all global DOM APIs properly.

I propose changing the mention to the new package, as it is a more future-proof option.

cc @modosc who is maintaining global-jsdom