### PR TITLE
docs: Fix broken link

### DIFF
--- a/docs/queries/bytext.mdx
+++ b/docs/queries/bytext.mdx
@@ -76,7 +76,7 @@ It also works with `input`s whose `type` attribute is either `submit` or
 
 > **Note**
 >
-> See [`getByLabelText`](bylabeltext#selector) for more details on how and when
+> See [`getByLabelText`](queries/bylabeltext.mdx#selector) for more details on how and when
 > to use the `selector` option
 
 ### `ignore`


### PR DESCRIPTION
Fix a broken link on this page : https://testing-library.com/docs/queries/bytext/

When clicking on the following it's redirecting  to a 404.

----
![Capture d’écran, le 2021-02-15 à 16 12 37](https://user-images.githubusercontent.com/1503758/107993549-ad713b00-6fa8-11eb-9539-1c873b95c2fb.jpg)
