### PR TITLE
🔧 Fix broken links across several doc pages

### DIFF
--- a/docs/marko-testing-library/api.mdx
+++ b/docs/marko-testing-library/api.mdx
@@ -90,11 +90,10 @@ few properties:
 ### `...queries`
 
 The most important feature of `render` is that the queries from
-[DOM Testing Library](dom-testing-library/api-queries.mdx) are automatically
-returned with their first argument bound to the results of rendering your
-component.
+[the Core API](queries/about.mdx) are automatically returned with their first
+argument bound to the results of rendering your component.
 
-See [Queries](dom-testing-library/api-queries.mdx) for a complete list.
+See [Queries](queries/about.mdx#types-of-queries) for a complete list.
 
 **Example**
 
@@ -119,7 +118,7 @@ debug()
 ```
 
 This is a simple wrapper around `prettyDOM` which is also exposed and comes from
-[`DOM Testing Library`](https://github.com/testing-library/dom-testing-library/blob/master/README.md#prettydom).
+[`DOM Testing Library`](dom-testing-library/api-debugging.mdx/#prettydom).
 
 ### `rerender`
 

--- a/docs/preact-testing-library/api.mdx
+++ b/docs/preact-testing-library/api.mdx
@@ -15,9 +15,8 @@ sidebar_label: API
 ## `@testing-library/dom`
 
 This library re-exports everything from the DOM Testing Library
-(`@testing-library/dom`). See the
-[documentation](dom-testing-library/api-queries.mdx) to see what goodies you can
-use.
+(`@testing-library/dom`). See the [documentation](queries/about.mdx) to see what
+goodies you can use.
 
 ## `render`
 
@@ -33,21 +32,21 @@ const { results } = render(<YourComponent />, { options })
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `container`   | The HTML element the component is mounted to.                                                                                                                     | baseElement   |
 | `baseElement` | The root HTML element to which the container is appended to.                                                                                                      | document.body |
-| `queries`     | Queries to bind to the baseElement. See [getQueriesForElement](dom-testing-library/api-helpers.mdx#within-and-getqueriesforelement-apis).                         | null          |
+| `queries`     | Queries to bind to the baseElement. See [within](dom-testing-library/api-within.mdx).                                                                             | null          |
 | `hydrate`     | Used when the component has already been mounted and requires a rerender. Not needed for most people. The rerender function passed back to you does this already. | false         |
 | `wrapper`     | A parent component to wrap YourComponent.                                                                                                                         | null          |
 
 ### Results
 
-| Result        | Description                                                                                                                                                                |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `container`   | The HTML element the component is mounted to.                                                                                                                              |
-| `baseElement` | The root HTML element to which the container is appended to.                                                                                                               |
-| `debug`       | Logs the baseElement using [prettyDom](dom-testing-library/api-helpers.mdx#prettydom).                                                                                     |
-| `unmount`     | Unmounts the component from the container.                                                                                                                                 |
-| `rerender`    | Calls render again passing in the original arguments and sets hydrate to true.                                                                                             |
-| `asFragment`  | Returns the innerHTML of the container.                                                                                                                                    |
-| `...queries`  | Returns all [query functions](dom-testing-library/api-queries.mdx) to be used on the baseElement. If you pass in `query` arguments than this will be those, otherwise all. |
+| Result        | Description                                                                                                                                              |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `container`   | The HTML element the component is mounted to.                                                                                                            |
+| `baseElement` | The root HTML element to which the container is appended to.                                                                                             |
+| `debug`       | Logs the baseElement using [prettyDom](dom-testing-library/api-debugging.mdx#prettydom).                                                                 |
+| `unmount`     | Unmounts the component from the container.                                                                                                               |
+| `rerender`    | Calls render again passing in the original arguments and sets hydrate to true.                                                                           |
+| `asFragment`  | Returns the innerHTML of the container.                                                                                                                  |
+| `...queries`  | Returns all [query functions](queries/about.mdx) to be used on the baseElement. If you pass in `query` arguments than this will be those, otherwise all. |
 
 ## `cleanup`
 

--- a/docs/preact-testing-library/learn.mdx
+++ b/docs/preact-testing-library/learn.mdx
@@ -15,10 +15,10 @@ If you're still hungry for more at this point than checkout:
 
 - The dom-testing-library:
   - [Introduction](intro.mdx)
-  - [Queries](dom-testing-library/api-queries.mdx)
+  - [Queries](queries/about.mdx)
   - [Firing Events](dom-testing-library/api-events.mdx)
   - [Async Utilities](dom-testing-library/api-async.mdx)
-  - [Helpers](dom-testing-library/api-helpers.mdx)
+  - [Helpers](dom-testing-library/api-custom-queries.mdx)
   - [FAQ](dom-testing-library/faq.mdx)
 - The react-testing-library:
   - [API](react-testing-library/api.mdx)

--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -175,9 +175,8 @@ All of the queries exported by DOM Testing Library accept a `container` as the
 first argument. Because querying the entire `document.body` is very common, DOM
 Testing Library also exports a `screen` object which has every query that is
 pre-bound to `document.body` (using the
-[`within`](/docs/dom-testing-library/api-helpers#within-and-getqueriesforelement-apis)
-functionality). Wrappers such as React Testing Library re-export `screen` so you
-can use it the same way.
+[`within`](/dom-testing-library/api-within.mdx) functionality). Wrappers such as
+React Testing Library re-export `screen` so you can use it the same way.
 
 Here's how you use it:
 

--- a/docs/react-testing-library/cheatsheet.mdx
+++ b/docs/react-testing-library/cheatsheet.mdx
@@ -130,16 +130,18 @@ See [Events API](dom-testing-library/api-events.mdx)
 
 ## Other
 
-See [Helpers API](dom-testing-library/api-helpers.mdx),
-[Config API](dom-testing-library/api-configuration.mdx)
+See [Querying Within Elements](dom-testing-library/api-within),
+[Config API](dom-testing-library/api-configuration.mdx),
+[Cleanup](react-testing-library/api.mdx#cleanup),
 
 - **within** take a node and return an object with all the queries bound to the
   node (used to return the queries from `React Testing Library`'s render
   method): `within(node).getByText("hello")`
 - **configure** change global options:
   `configure({testIdAttribute: 'my-data-test-id'})`
-- **cleanup** clears the DOM ([use with `afterEach`](setup.mdx#cleanup) to reset
-  DOM between tests)
+- **cleanup** clears the DOM
+  ([use with `afterEach`](react-testing-library/api.mdx#cleanup) to reset DOM
+  between tests)
 
 ## Text Match Options
 

--- a/docs/react-testing-library/faq.mdx
+++ b/docs/react-testing-library/faq.mdx
@@ -211,7 +211,7 @@ test has already finished. There are 2 approaches to resolve it:
 1. Wait for the result of the operation in your test by using one of
    [the async utilities](dom-testing-library/api-async.mdx) like
    [wait](dom-testing-library/api-async.mdx#wait) or a
-   [`find*` query](dom-testing-library/api-queries.mdx#findby). For example:
+   [`find*` query](queries/about.mdx#types-of-queries). For example:
    `const userAddress = await findByLabel(/address/i)`.
 2. Mocking out the asynchronous operation so that it doesn't trigger state
    updates.

--- a/docs/react-testing-library/migrate-from-enzyme.mdx
+++ b/docs/react-testing-library/migrate-from-enzyme.mdx
@@ -199,10 +199,10 @@ automatically cleans up the output for each test, so you don't need to call
 
 The other thing that you might notice is `getByRole` which has `heading` as its
 value. `heading` is the accessible role of the `h1` element. You can learn more
-about them on [queries](dom-testing-library/api-queries.mdx#byrole)
-documentation page. One of the things people quickly learn to love about Testing
-Library is how it encourages you to write more accessible applications (because
-if it's not accessible, then it's harder to test).
+about them on the [queries](queries/byrole.mdx) documentation page. One of the
+things people quickly learn to love about Testing Library is how it encourages
+you to write more accessible applications (because if it's not accessible, then
+it's harder to test).
 
 ### Test 2: Input texts must have correct value
 
@@ -242,9 +242,8 @@ default `role` values and you don't need to set one for them, but some others
 like `<div>` do not have one. You could use different approaches to access the
 `<div>` element, but we recommend trying to access elements by their implicit
 `role` to make sure your component is accessible by people with disabilities and
-those who are using screen readers. This
-[section](dom-testing-library/api-queries.mdx#byrole) of the query page might
-help you to understand better.
+those who are using screen readers. This [section](queries/byrole.mdx) of the
+query page might help you to understand better.
 
 > Keep in mind that a `<form>` must have a `name` attribute in order to have an
 > implicit `role` of `form` (as required by the specification).
@@ -258,7 +257,7 @@ it's not recommended for the reasons stated in this paragraph).
 
 We made some handy query APIs which help you to access the component elements
 very efficiently, and you can see the
-[list of available queries](dom-testing-library/api-queries.mdx) in detail.
+[list of available queries](queries/about.mdx#types-of-queries) in detail.
 
 Something else that people have a problem with is that they're not sure which
 query should they use, luckily we have a great page which explains

--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -15,9 +15,8 @@ sidebar_label: API
 ## `@testing-library/dom`
 
 This library re-exports everything from the DOM Testing Library
-(`@testing-library/dom`). See the
-[documentation](dom-testing-library/api-queries.mdx) to see what goodies you can
-use.
+(`@testing-library/dom`). See the [documentation](queries/about.mdx) to see what
+goodies you can use.
 
 📝 `fireEvent` is an `async` method when imported from
 `@testing-library/svelte`. This is because it calls [`tick`][svelte-tick] which
@@ -57,10 +56,10 @@ const { results } = render(YourComponent, { myProp: 'value' })
 
 ### Render Options
 
-| Option      | Description                                                                                                                             | Default         |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `container` | The HTML element the component is mounted into.                                                                                         | `document.body` |
-| `queries`   | Queries to bind to the container. See [getQueriesForElement](dom-testing-library/api-helpers.mdx#within-and-getqueriesforelement-apis). | `null`          |
+| Option      | Description                                                                         | Default         |
+| ----------- | ----------------------------------------------------------------------------------- | --------------- |
+| `container` | The HTML element the component is mounted into.                                     | `document.body` |
+| `queries`   | Queries to bind to the container. See [within](dom-testing-library/api-within.mdx). | `null`          |
 
 ### Results
 
@@ -68,10 +67,10 @@ const { results } = render(YourComponent, { myProp: 'value' })
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `container`  | The HTML element the component is mounted into.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `component`  | The newly created Svelte component. Generally, this should only be used when testing exported functions, or when you're testing developer facing API's. Outside of said cases avoid using the component directly to build tests, instead of interacting with the rendered Svelte component, work with the DOM. Have a read of [Avoid the Test User](https://kentcdodds.com/blog/avoid-the-test-user) by Kent C. Dodds to understand the difference between the **end user** and **developer user**. |
-| `debug`      | Logs the `container` using [prettyDom](dom-testing-library/api-helpers.mdx#prettydom).                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `debug`      | Logs the `container` using [prettyDom](dom-testing-library/api-debugging.mdx/#prettydom).                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `unmount`    | Unmounts the component from the `target` by calling `component.$destroy()`.                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `rerender`   | Calls render again destroying the old component, and mounting the new component on the original `target` with any new options passed in.                                                                                                                                                                                                                                                                                                                                                            |
-| `...queries` | Returns all [query functions](dom-testing-library/api-queries.mdx) that are bound to the `container`. If you pass in `query` arguments than this will be those, otherwise all.                                                                                                                                                                                                                                                                                                                      |
+| `...queries` | Returns all [query functions](queries/about.mdx) that are bound to the `container`. If you pass in `query` arguments than this will be those, otherwise all.                                                                                                                                                                                                                                                                                                                                        |
 
 ## `cleanup`
 

--- a/docs/testcafe-testing-library/intro.mdx
+++ b/docs/testcafe-testing-library/intro.mdx
@@ -39,7 +39,7 @@ find[All]By\* selectors that you can use in your tests.
 
 `import { screen } from '@testing-library/testcafe'`
 
-[See `DOM Testing Library` API for reference](dom-testing-library/api-queries.mdx)
+[See `Queries` for reference](queries/about.mdx)
 
 > A note about queries in testcafe. Testcafe has
 > [built in waiting](https://devexpress.github.io/testcafe/documentation/test-api/built-in-waiting-mechanisms.html#wait-mechanism-for-selectors),

--- a/docs/vue-testing-library/api.mdx
+++ b/docs/vue-testing-library/api.mdx
@@ -187,7 +187,7 @@ debug()
 ```
 
 This is a simple wrapper around `prettyDOM` which is also exposed and comes from
-[`DOM Testing Library`](https://github.com/testing-library/dom-testing-library/blob/master/README.md#prettydom).
+[`DOM Testing Library`](dom-testing-library/api-debugging.mdx/#prettydom).
 
 #### `unmount()`
 

--- a/docs/vue-testing-library/faq.mdx
+++ b/docs/vue-testing-library/faq.mdx
@@ -30,8 +30,8 @@ re-exports it.
 <details>
   <summary>What queries does Vue Testing Library provide?</summary>
 
-All queries from DOM Testing Library. See
-[Queries](dom-testing-library/api-queries.mdx) for full list.
+All queries from DOM Testing Library. See [Queries](queries/about.mdx) for full
+list.
 
 </details>
 

--- a/docs/vue-testing-library/intro.mdx
+++ b/docs/vue-testing-library/intro.mdx
@@ -26,7 +26,7 @@ npm install --save-dev @testing-library/vue
 
 You can now use all of `DOM Testing Library`'s `getBy`, `getAllBy`, `queryBy`
 and `queryAllBy` commands. See here the
-[full list of queries](dom-testing-library/api-queries.mdx).
+[full list of queries](queries/about.mdx#types-of-queries).
 
 You may also be interested in installing `jest-dom` so you can use
 [the custom Jest matchers](https://github.com/gnapse/jest-dom#readme) for the


### PR DESCRIPTION
Hi there! Thanks for overall a very comprehensive set of docs. I just got started on migrating our team from Enzyme to react-testing-library today, having never used it before, and was impressed with how good the docs are.

I did come across a few broken links on the way when looking at the Migrating from Enzyme page, today, though, so thought I'd try to fix what I found! I pulled the docs repo down and ran it locally and it did warn about 20 unresolvable internal links, only some of which were to the old queries page under dom-testing-library, so I tried to fix the remaining ones, too.

Keep in mind I'm not super familiar with the project yet, so some of the references to new pages may not be entirely accurate. I'm particularly not sure about the reorganisation of helper/debugging methods, so please shout if some of that could be improved, but I'm fairly certain that all the links to the new top-level queries documentation are going to be roughly accurate.

I did notice there's a redirect set up for these, but they don't always appear to work, particularly for relative links and links with an internal document anchor. So some of these links I'm updating may have technically worked before thanks to the redirect, but figured there'd be no harm in updating the source to point at the correct docs to begin with :)