### PR TITLE
Remove duplicate "Custom Queries" title

### DIFF
--- a/docs/dom-testing-library/api-custom-queries.mdx
+++ b/docs/dom-testing-library/api-custom-queries.mdx
@@ -6,8 +6,6 @@ title: Custom Queries
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
-## Custom Queries
-
 `DOM Testing Library` exposes many of the helper functions that are used to
 implement the default queries. You can use the helpers to build custom queries.
 For example, the code below shows a way to override the default `testId` queries


### PR DESCRIPTION
Now the custom queries page look like this and has the same title repeated at the top of the page, and it can be removed since it's not necessary

![image](https://user-images.githubusercontent.com/7496103/109226919-c86d5780-77bf-11eb-8bf8-1a3de1daa72d.png)
