### PR TITLE
docs(react-testing-library): warn about afterEach auto cleanup footgun

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -19,6 +19,16 @@ require that you use Jest).
 Adding options to your global test config can simplify the setup and teardown of
 tests in individual files.
 
+## Safe cleanup
+
+`React Testing Library` will auto `cleanup` rendered components in all 
+frameworks that expose an `afterEach` API. Be warned, however, that any `async` 
+`afterEach` handlers you register that _defers_ the RTL `cleanup` call will 
+leave opporitunity for your rendered components to continue process react state
+updates and emit `act()` errors. If you implement custom async `afterEach` 
+handlers, it is recommended to call `cleanup` explicity before any async 
+behavior.
+
 ## Custom Render
 
 It's often useful to define a custom render method that includes things like


### PR DESCRIPTION
# Problem

Our tests implement an `afterEach(async () => { /* ... */ })` handler. We registered it, thinking all was well! However, jest processes afterEach handlers in reverse order of registration. That means that our integration test execute, effects could be outstanding due to interactions in the test, the test block exits, our `afterEach` _perhaps_ take a little bit of time to complete, the react effects settle from the integration test, and an `act()` error is emitted. Only after our `afterEach` promise settles does RTL `cleanup()` get invoked, prompting effect teardown/cancellation, etc.

We wrote code that makes it s.t. `act()` errors fail our tests. With the above scenario, we found our tests to have some degree of flakiness in noisy/inconsistent environments (like a busy CI agent).

The implicit behavior of RTL, I found, was actually undesirable. If I had known `cleanup` was a RTL provision, I would have more rapidly identified it as a potential culprit in our failures. Generally, side-effects as imports can be risky, with general exception when you explicitly import a verb, like `babel/register`, etc.

I suspect other community members have periodic act() errors that they consider ghosts in the system, when perhaps they really need to look at their own `afterEach()` handlers!

Let's warn those users! :)