### PR TITLE
docs: Example of testing for absence of an element

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -169,6 +169,19 @@ const container = document.querySelector('#app')
 const inputNode2 = getByLabelText(container, 'Username')
 ```
 
+Similarly, you can use a query to test the absence of an element (byLabelText, in this case):
+
+```js
+import { screen, queryByLabelText } from '@testing-library/dom'
+
+// With screen:
+expect(screen.queryAllByLabelText('Username')).toHaveLength(0);
+
+// Without screen, you need to provide a container:
+const container = document.querySelector('#app')
+expect(queryAllByLabelText(container, 'Username')).toHaveLength(0);
+```
+
 ### `screen`
 
 All of the queries exported by DOM Testing Library accept a `container` as the


### PR DESCRIPTION
We were having a debate amongst some colleagues about the best way to test for absence of an element/text

There are a number of approaches so we thought perhaps it was something the docs could recommend an approach for

The approaches for labels are

```js
expect(screen.queryByLabelText("something")).toBeFalsy()
expect(screen.queryAllByLabelText("something")).toHaveLength(0)
expect(container).not.toHaveTextContent("something")
```

For text content, the equivalents would be 

```js
expect(screen.queryByText("something")).toBeFalsy()
expect(screen.queryAllByText("something")).toHaveLength(0)
expect(container).not.toHaveTextContent("something")
```

Thoughts?