### PR TITLE
docs: modify selectoption example to be more accesible

### DIFF
--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -279,26 +279,20 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-test('selectOptions', () => {
+it('selectOptions', () => {
   render(
-    <select multiple data-testid="select-multiple">
-      <option data-testid="val1" value="1">
-        A
-      </option>
-      <option data-testid="val2" value="2">
-        B
-      </option>
-      <option data-testid="val3" value="3">
-        C
-      </option>
+    <select multiple>
+      <option value="1">A</option>
+      <option value="2">B</option>
+      <option value="3">C</option>
     </select>
   )
 
-  userEvent.selectOptions(screen.getByTestId('select-multiple'), ['1', '3'])
+  userEvent.selectOptions(screen.getByRole('listbox'), ['1', '3'])
 
-  expect(screen.getByTestId('val1').selected).toBe(true)
-  expect(screen.getByTestId('val2').selected).toBe(false)
-  expect(screen.getByTestId('val3').selected).toBe(true)
+  expect(screen.getByRole('option', { name: 'A' }).selected).toBe(true)
+  expect(screen.getByRole('option', { name: 'B' }).selected).toBe(false)
+  expect(screen.getByRole('option', { name: 'C' }).selected).toBe(true)
 })
 ```
 

--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -279,7 +279,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-it('selectOptions', () => {
+test('selectOptions', () => {
   render(
     <select multiple>
       <option value="1">A</option>


### PR DESCRIPTION
# Motivation
I was looking around the `user-event` documentation for testing the behaviour of a select component I am building in my app.
I found that the example provided could be more accesible and better aligned with the guidelines and principles of the testing-library. IMHO these kind of examples can make newcomers to have an easier journey learning the library and its core principles.

### Disclaimer

This is my first contribution to the project so apologies in advance if I am making any mistake. 😃