### PR TITLE
docs(testing-library-angular): Adjust url of the github example-app

### DIFF
--- a/docs/angular-testing-library/examples.mdx
+++ b/docs/angular-testing-library/examples.mdx
@@ -60,7 +60,7 @@ describe('Counter', () => {
 ```
 
 More examples can be found in the
-[GitHub project](https://github.com/testing-library/angular-testing-library/tree/master/apps/example-app/app/examples).
+[GitHub project](https://github.com/testing-library/angular-testing-library/tree/master/apps/example-app/src/app/examples).
 These examples include:
 
 - `@Input` and `@Output` properties


### PR DESCRIPTION
The url of the example-app has changed due to changes in the structure of the example-app. Code is moved to the `example-app/src` folder

@see https://github.com/testing-library/angular-testing-library/pull/199