### PR TITLE
Change wait to waitFor in cheatsheet

### DIFF
--- a/docs/vue-testing-library/cheatsheet.mdx
+++ b/docs/vue-testing-library/cheatsheet.mdx
@@ -55,7 +55,7 @@ For more information, see
 
 ## Async utilities
 
-- **wait** (Promise) retry function within until it stops throwing or times out.
+- **waitFor** (Promise) retry function within until it stops throwing or times out.
 - **waitForElement** (Promise) retry function or array of functions and return
   the result.
 - `findBy` and `findAllBy` queries are async and retry until either a timeout or


### PR DESCRIPTION
Changed because when I was following this docs, I got a deprecation warning that I should use waitFor instead of wait.