### PR TITLE
docs: Add missing RenderOptions import

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -79,7 +79,7 @@ export { customRender as render }
 
 ```tsx title="test-utils.tsx"
 import React, { FC } from 'react'
-import { render } from '@testing-library/react'
+import { render, RenderOptions } from '@testing-library/react'
 import { ThemeProvider } from 'my-ui-lib'
 import { TranslationProvider } from 'my-i18n-lib'
 import defaultStrings from 'i18n/en-x-default'


### PR DESCRIPTION
For #800

#### Background
Just adding a missing type `RenderOptions` in [Setup/Custom Render](https://testing-library.com/docs/react-testing-library/setup#custom-render) for TypeScript example.
#### Change List
- Modify `docs/react-testing-library/setup.mdx` TypeScript example adding `RenderOptions` type from `@testing-library/react`