### PR TITLE
docs: Correct queryBy* definition

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -51,7 +51,7 @@ test('should show login form', () => {
   - `getBy...`: Returns the matching node for a query, and throw a descriptive
     error if no elements match _or_ if more than one match is found (use
     `getAllBy` instead if more than one element is expected).
-  - `queryBy...`: Returns the first matching node for a query, and return `null`
+  - `queryBy...`: Returns the matching node for a query, and return `null`
     if no elements match. This is useful for asserting an element that is not
     present. Throws an error if more than one match is found (use `queryAllBy`
     instead if this is OK).


### PR DESCRIPTION
Doc page:
https://testing-library.com/docs/queries/about/#types-of-queries

`queryBy*` returns the only match of an element, not the first one. In that case, it'll throw an Error.