### PR TITLE
docs: Fix custom queries example

### DIFF
--- a/docs/dom-testing-library/api-custom-queries.mdx
+++ b/docs/dom-testing-library/api-custom-queries.mdx
@@ -47,11 +47,15 @@ export function getAllByTestId(container, id, ...rest) {
 }
 
 export function getByTestId(...args) {
+  // result >= 1
   const result = getAllByTestId(...args)
-  if (result.length > 0) {
-    return result[0]
+  if (result.length > 1) {
+    throw queryHelpers.getElementError(
+      `Found multiple elements with the [data-test-id="${id}"]`,
+      container
+    )
   }
-  return null
+  return result[0]
 }
 
 // re-export with overrides


### PR DESCRIPTION
Doc page:
https://testing-library.com/docs/dom-testing-library/api-custom-queries

`getBy*` queries should throw an error after finding more than 1 element!