### PR TITLE
docs: Replace deprecated api

### DIFF
--- a/docs/react-testing-library/faq.mdx
+++ b/docs/react-testing-library/faq.mdx
@@ -210,7 +210,7 @@ test has already finished. There are 2 approaches to resolve it:
 
 1. Wait for the result of the operation in your test by using one of
    [the async utilities](dom-testing-library/api-async.mdx) like
-   [wait](dom-testing-library/api-async.mdx#wait) or a
+   [waitFor](dom-testing-library/api-async.mdx#waitFor) or a
    [`find*` query](dom-testing-library/api-queries.mdx#findby). For example:
    `const userAddress = await findByLabel(/address/i)`.
 2. Mocking out the asynchronous operation so that it doesn't trigger state


### PR DESCRIPTION
oc page: (q6)
https://testing-library.com/docs/react-testing-library/faq

Replace `wait` which is deprecated with `waitFor`.