### PR TITLE
Docs: Fix react testing library printable cheatsheet link

### DIFF
--- a/docs/react-testing-library/cheatsheet.mdx
+++ b/docs/react-testing-library/cheatsheet.mdx
@@ -170,4 +170,4 @@ getByText((content, element) => content.startsWith('Hello'))
 **[Get the printable cheat sheet][cheatsheet]**
 
 [cheatsheet]:
-  https://github.com/testing-library/react-testing-library/raw/master/other/cheat-sheet.pdf
+  https://github.com/testing-library/react-testing-library/raw/main/other/cheat-sheet.pdf


### PR DESCRIPTION
The printable cheatsheet link on [this page](https://testing-library.com/docs/react-testing-library/cheatsheet) seems to be broken since gitlab renamed `master` branch to `main`