### PR TITLE
docs(user-event): Remove strange argument passing

### DIFF
--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -264,8 +264,8 @@ import userEvent from '@testing-library/user-event'
 test('clear', () => {
   render(<textarea value="Hello, World!" />)
 
-  userEvent.clear(screen.getByRole('textbox', 'email'))
-  expect(screen.getByRole('textbox', 'email')).toHaveAttribute('value', '')
+  userEvent.clear(screen.getByRole('textbox'))
+  expect(screen.getByRole('textbox')).toHaveAttribute('value', '')
 })
 ```
 


### PR DESCRIPTION
If I correclty understand `screen.getByRole()` method signature, we shouldn't pass here two string arguments.
And, according to [WAI-ARIA spec](https://w3c.github.io/html-aria/), there is no `email` role.