### PR TITLE
docs: Remove example of synthetic right clicks

### DIFF
--- a/docs/dom-testing-library/api-events.mdx
+++ b/docs/dom-testing-library/api-events.mdx
@@ -41,13 +41,6 @@ Convenience methods for firing DOM events. Check out
 [src/event-map.js](https://github.com/testing-library/dom-testing-library/blob/master/src/event-map.js)
 for a full list as well as default `eventProperties`.
 
-```javascript
-// <button>Submit</button>
-const rightClick = { button: 2 }
-fireEvent.click(getByText('Submit'), rightClick)
-// default `button` property for click events is set to `0` which is a left click.
-```
-
 **target**: When an event is dispatched on an element, the event has the
 subjected element on a property called `target`. As a convenience, if you
 provide a `target` property in the `eventProperties` (second argument), then


### PR DESCRIPTION
These should not be observable in a browser. Since we're all about testing how a user interacts, we should not document these esoteric usages.

Closes https://github.com/testing-library/testing-library-docs/issues/469