### PR TITLE
Update docs to suggest @testing-library/jest-dom

### DIFF
--- a/docs/vue-testing-library/intro.mdx
+++ b/docs/vue-testing-library/intro.mdx
@@ -28,8 +28,8 @@ You can now use all of `DOM Testing Library`'s `getBy`, `getAllBy`, `queryBy`
 and `queryAllBy` commands. See here the
 [full list of queries](dom-testing-library/api-queries.mdx).
 
-You may also be interested in installing `jest-dom` so you can use
-[the custom Jest matchers](https://github.com/gnapse/jest-dom#readme) for the
+You may also be interested in installing `@testing-library/jest-dom` so you can use
+[the custom Jest matchers](https://github.com/testing-library/jest-dom#readme) for the
 DOM.
 
 ## The problem


### PR DESCRIPTION
Otherwise, users get a warning when installing `jest-dom`