### PR TITLE
docs: format the deprecation section in DOM cheatsheet

### DIFF
--- a/docs/dom-testing-library/cheatsheet.mdx
+++ b/docs/dom-testing-library/cheatsheet.mdx
@@ -90,8 +90,8 @@ See [Async API](dom-testing-library/api-async.mdx). Remember to `await` or
 > - **wait** (Promise) retry the function within until it stops throwing or
 >   times
 > - **waitForElement** (Promise) retry the function until it returns an element
->   or an array of elements. `findBy` and `findAllBy` queries are async and
->   retry until either a timeout or if the query returns successfully; they wrap
+>   or an array of elements. The `findBy` and `findAllBy` queries are async and
+>   retry until the query returns successfully, or when the query times out; they wrap
 >   `waitForElement`
 > - **waitForDomChange** (Promise) retry the function each time the DOM is
 >   changed

--- a/docs/dom-testing-library/cheatsheet.mdx
+++ b/docs/dom-testing-library/cheatsheet.mdx
@@ -90,9 +90,9 @@ See [Async API](dom-testing-library/api-async.mdx). Remember to `await` or
 > - **wait** (Promise) retry the function within until it stops throwing or
 >   times
 > - **waitForElement** (Promise) retry the function until it returns an element
->   or an array of elements
-> - `findBy` and `findAllBy` queries are async and retry until either a timeout
->   or if the query returns successfully; they wrap `waitForElement`
+>   or an array of elements. `findBy` and `findAllBy` queries are async and
+>   retry until either a timeout or if the query returns successfully; they wrap
+>   `waitForElement`
 > - **waitForDomChange** (Promise) retry the function each time the DOM is
 >   changed
 


### PR DESCRIPTION
The [Async section](https://testing-library.com/docs/dom-testing-library/cheatsheet#async) on the DOM cheatsheet page has a small formatting issue which causes the `findBy` and `findAllBy` queries to be listed as deprecated APIs. (I got a mini heart attack there to be honest)

<img width="828" alt="Screen Shot 2021-05-14 at 15 13 39" src="https://user-images.githubusercontent.com/25715018/118242211-47248780-b4c7-11eb-8977-4e81bd3ea490.png">

---

This PR formats that line a bit, so that it is part of the `waitForElement` paragraph. Here is the result:

<img width="963" alt="Screen Shot 2021-05-14 at 14 33 30" src="https://user-images.githubusercontent.com/25715018/118242700-cdd96480-b4c7-11eb-9f5f-82fece01d382.png">

