### PR TITLE
fix: importing missing ReactElement type

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -78,7 +78,7 @@ export { customRender as render }
 ```
 
 ```tsx title="test-utils.tsx"
-import React, { FC } from 'react'
+import React, { FC, ReactElement } from 'react'
 import { render, RenderOptions } from '@testing-library/react'
 import { ThemeProvider } from 'my-ui-lib'
 import { TranslationProvider } from 'my-i18n-lib'


### PR DESCRIPTION
Just importing missing ReactElement type on the following page:

https://testing-library.com/docs/react-testing-library/setup

![image](https://user-images.githubusercontent.com/4874089/118794568-fda6b480-b899-11eb-9420-ecf7b1e3d9c2.png)
