### PR TITLE
Updated Formik testing example, added a missing parameter

### DIFF
--- a/docs/example-formik.md
+++ b/docs/example-formik.md
@@ -14,9 +14,9 @@ import { Formik, Field, Form } from 'formik'
 const sleep = ms => new Promise(r => setTimeout(r, ms))
 
 export const MyForm = ({ onSubmit }) => {
-  const handleSubmit = async values => {
+  const handleSubmit = async (values, formikBag) => {
     await sleep(500)
-    onSubmit(values)
+    onSubmit(values, formikBag)
   }
 
   return (


### PR DESCRIPTION
[This PR](https://github.com/testing-library/testing-library-docs/pull/692) forgot to add the second onSubmit parameter in the example code, which causes the testing to always fail.

```
  ● rendering and submitting a basic Formik form

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    - Expected
    + Received

      {"email": "john.dee@someemail.com", "firstName": "John", "lastName": "Dee"},
    - Anything,

    Number of calls: 1
```
