### PR TITLE
docs(ecosystem/eslint): update link for the ESLint plugin

### DIFF
--- a/docs/ecosystem-eslint-plugin-testing-library.mdx
+++ b/docs/ecosystem-eslint-plugin-testing-library.mdx
@@ -20,4 +20,4 @@ Find more info about available rules and configs on GitHub.
 
 - [eslint-plugin-testing-library on GitHub][gh]
 
-[gh]: https://github.com/Belco90/eslint-plugin-testing-library
+[gh]: https://github.com/testing-library/eslint-plugin-testing-library


### PR DESCRIPTION
The ESLint plugin has moved to https://github.com/testing-library/eslint-plugin-testing-library