### PR TITLE
Add peer dependency to User Event docs

### DIFF
--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -12,7 +12,7 @@ advanced simulation of browser interactions than the built-in
 ## Install
 
 ```
-npm install --save-dev @testing-library/user-event
+npm install --save-dev @testing-library/user-event @testing-library/dom
 ```
 
 ```jsx


### PR DESCRIPTION
User Event peer depends on DOM Testing Library, so it needs to be manually installed, as stated in the readme.