### PR TITLE
docs: typo fix

### DIFF
--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -175,7 +175,7 @@ renders its HTML directly in the body.
 ### `debug`
 
 > NOTE: It's recommended to use
-> [`screen.debug`](queries/about.mdx#api-queries#screendebug) instead.
+> [`screen.debug`](queries/about.mdx#screendebug) instead.
 
 This method is a shortcut for `console.log(prettyDOM(baseElement))`.
 


### PR DESCRIPTION
Just a quick fix for URL pointing to `screen.debug` documentation.