### PR TITLE
docs: fix react-router-example test-case(#897)

### DIFF
--- a/docs/example-react-router.mdx
+++ b/docs/example-react-router.mdx
@@ -49,19 +49,14 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {createMemoryHistory} from 'history'
 import React from 'react'
-import {Router} from 'react-router-dom'
+import {Router, MemoryRouter} from 'react-router-dom'
 
 import '@testing-library/jest-dom/extend-expect'
 
 import {App, LocationDisplay} from './app'
 
 test('full app rendering/navigating', () => {
-  const history = createMemoryHistory()
-  render(
-    <Router history={history}>
-      <App />
-    </Router>,
-  )
+  render(<App />, {wrapper: MemoryRouter})
   // verify page content for expected route
   // often you'd use a data-testid or role query, but this is also possible
   expect(screen.getByText(/you are home/i)).toBeInTheDocument()


### PR DESCRIPTION
*docs: update example-react-route.mdx

*docs: replace createMemoryHistory with MemoryRouter for first test-case