### PR TITLE
Fixes findByText usage in Cypress example test

### DIFF
--- a/docs/cypress-testing-library/intro.mdx
+++ b/docs/cypress-testing-library/intro.mdx
@@ -58,7 +58,7 @@ cy.findByRole('button', {name: /Button Text/i}).should('exist')
 cy.findByRole('button', {name: /Non-existing Button Text/i}).should('not.exist')
 cy.findByLabelText(/Label text/i, {timeout: 7000}).should('exist')
 
-// findAllByText _inside_ a form element
+// findByText _inside_ a form element
 cy.get('form')
   .findByText(/Button Text/i)
   .should('exist')

--- a/docs/cypress-testing-library/intro.mdx
+++ b/docs/cypress-testing-library/intro.mdx
@@ -60,7 +60,7 @@ cy.findByLabelText(/Label text/i, {timeout: 7000}).should('exist')
 
 // findByText _inside_ a form element
 cy.get('form')
-  .findByText(/Button Text/i)
+  .findByRole('button', {name: /Button Text/i})
   .should('exist')
 cy.findByRole('dialog').within(() => {
   cy.findByRole('button', {name: /confirm/i})

--- a/docs/cypress-testing-library/intro.mdx
+++ b/docs/cypress-testing-library/intro.mdx
@@ -58,7 +58,7 @@ cy.findByRole('button', {name: /Button Text/i}).should('exist')
 cy.findByRole('button', {name: /Non-existing Button Text/i}).should('not.exist')
 cy.findByLabelText(/Label text/i, {timeout: 7000}).should('exist')
 
-// findByText _inside_ a form element
+// findByRole _inside_ a form element
 cy.get('form')
   .findByRole('button', {name: /Button Text/i})
   .should('exist')

--- a/docs/cypress-testing-library/intro.mdx
+++ b/docs/cypress-testing-library/intro.mdx
@@ -60,7 +60,7 @@ cy.findByLabelText(/Label text/i, {timeout: 7000}).should('exist')
 
 // findAllByText _inside_ a form element
 cy.get('form')
-  .findByText('button', {name: /Button Text/i})
+  .findByText(/Button Text/i)
   .should('exist')
 cy.findByRole('dialog').within(() => {
   cy.findByRole('button', {name: /confirm/i})


### PR DESCRIPTION
It seems that chained `.findByText()` API was used incorrectly incorrectly. Running the example on the Cypress page with the HTML below results in this error:
<img width="486" alt="image" src="https://user-images.githubusercontent.com/15187179/128259818-aac58aa8-94e3-4f3c-835e-fb65edac7509.png">

These changes allow the test to succeed.

I specifically ran into this because I tried copy/pasting this example and altering it for my site and I was confused as to why it wasn't working.





___

Example HTML
```html
<!DOCTYPE html>
<html>
<body>
  <button>Jackie Chan</button>
  <form>
    <label for="input">Label text</label>
    <input type="text" id="input">
    <button type="button">Button Text</button>
  </form>
  <dialog open>
    <p>Do you want to read the docs?</p>
    <button>Confirm</button>
  </dialog>
</body>
</html>
```
