### PR TITLE
Make summary table details open by default.

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -72,7 +72,7 @@ test('should show login form', () => {
       `waitFor` options as the last argument (i.e.
       `await screen.findByText('text', queryOptions, waitForOptions)`)
 
-<details>
+<details open>
 
 <summary>Summary Table</summary>
 


### PR DESCRIPTION
It's very easy to miss the summary table - which is like the most useful part of the page. Have it open by default.