### PR TITLE
docs: fix typo in example import

### DIFF
--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -107,7 +107,7 @@ merged.
 
 ```js
 // Example, a function to traverse table contents
-import * as tableQueries from 'my-table-query-libary'
+import * as tableQueries from 'my-table-query-library'
 import {queries} from '@testing-library/react'
 
 const {getByRowColumn, getByText} = render(<MyTable />, {


### PR DESCRIPTION
Fixed 'libary' to 'library' in: import * as tableQueries from 'my...