### PR TITLE
docs: fix broken React Native Testing Library links

### DIFF
--- a/blog/2019-04-25-new-org.mdx
+++ b/blog/2019-04-25-new-org.mdx
@@ -123,22 +123,17 @@ there.) Please join us!
 
 > [Join us on Spectrum](https://spectrum.chat/testing-library)
 
-## [Testing Library on React Native](https://www.native-testing-library.com/)
+## [Testing Library on React Native](https://callstack.github.io/react-native-testing-library/)
 
 I'm really happy to announce a super solution to the React Native testing space.
 The DOM is quite different from native, as I mentioned before, it's not the code
 but the concepts that really make the Testing Library great. I'm happy to say
-that [Brandon Carroll](https://twitter.com/bcarroll22) has successfully ported
+that [Brandon Carroll](https://github.com/bcarroll22) has successfully ported
 those concepts to a solution for React Native and I'm really happy with it. Give
 it a look if you're building React Native applications and want confidence that
 they continue to work as you make changes!
 
-(Note, there is already `react-native-testing-library`, but it doesn't quite
-follow the guiding principles of Testing Library, so we recommend you use
-`native-testing-library`.
-[Learn More](https://medium.com/@brandoncarroll/why-native-testing-library-exists-629ffb85cae2)).
-
-> [Checkout native-testing-library](https://www.native-testing-library.com/)
+> [Checkout native-testing-library](https://callstack.github.io/react-native-testing-library/)
 
 ## [Learn Testing Library](https://testing-library.com/docs/learning)
 
@@ -179,7 +174,7 @@ an especially significant impact on the Testing Library family of tools and
 community.
 
 [Myself 👋](https://kentcdodds.com), [Alex Krolick](https://alexkrolick.com/),
-[Brandon Carroll](https://twitter.com/bcarroll22),
+[Brandon Carroll](https://github.com/bcarroll22),
 [Giorgio](https://twitter.com/Gpx),
 [Ernesto García](https://twitter.com/gnapse), and
 [Daniel Cook](https://github.com/dfcook).


### PR DESCRIPTION
The old link `https://www.native-testing-library.com/` seems to have been taken over by a malicious website. I replaced links with the new RNTL docs and Brandon's GitHub (his Twitter is deleted, which means it would also be taken over by a malicious account).