### PR TITLE
docs: remove invalid URL

### DIFF
--- a/docs/learning.mdx
+++ b/docs/learning.mdx
@@ -21,8 +21,6 @@ sidebar_label: Learning Material
   by [@iwilsonq](https://github.com/iwilsonq)
 - [A clear way to unit testing React JS components using Jest and React Testing Library](https://www.richardkotze.com/coding/react-testing-library-jest)
   by [Richard Kotze](https://github.com/rkotze)
-- [Intro to React Testing Library](https://chrisnoring.gitbooks.io/react/content/testing/react-testing-library.html)
-  by [Chris Noring](https://github.com/softchris)
 - [Integration testing in React](https://medium.com/@jeffreyrussom/integration-testing-in-react-21f92a55a894)
   by [Jeffrey Russom](https://github.com/qswitcher)
 - [React Testing Library have fantastic testing 🐐](https://medium.com/yazanaabed/react-testing-library-have-a-fantastic-testing-198b04699237)


### PR DESCRIPTION
I found that some URL already moved and not found.

Closes https://github.com/testing-library/testing-library-docs/issues/923