### PR TITLE
docs: fix links to query list for Vue

### DIFF
--- a/docs/vue-testing-library/faq.mdx
+++ b/docs/vue-testing-library/faq.mdx
@@ -31,7 +31,7 @@ re-exports it.
   <summary>What queries does Vue Testing Library provide?</summary>
 
 All queries from DOM Testing Library. See
-[Queries](dom-testing-library/api-queries.mdx) for full list.
+[Queries](cheatsheet#queries) for full list.
 
 </details>
 

--- a/docs/vue-testing-library/intro.mdx
+++ b/docs/vue-testing-library/intro.mdx
@@ -26,7 +26,7 @@ npm install --save-dev @testing-library/vue
 
 You can now use all of `DOM Testing Library`'s `getBy`, `getAllBy`, `queryBy`
 and `queryAllBy` commands. See here the
-[full list of queries](docs/queries/about/#types-of-queries).
+[full list of queries](cheatsheet#queries).
 
 You may also be interested in installing `@testing-library/jest-dom` so you can
 use


### PR DESCRIPTION
# This PR fixes issue [925](https://github.com/testing-library/testing-library-docs/issues/925)

## Description:
* updated the links to use this [this list](https://testing-library.com/docs/vue-testing-library/cheatsheet#queries) instead