### PR TITLE
pecies.mdx: add React Testing Library React Dnd Chessboard Example

### DIFF
--- a/docs/recipes.mdx
+++ b/docs/recipes.mdx
@@ -5,3 +5,5 @@ title: About the Examples
 
 [Examples](./example-codesandbox) and [Help Resources](./learning) are
 contributed by the Testing Library community
+
+- [React Testing Library React Dnd Chessboard Example](https://github.com/laststance/react-testing-library-react-dnd-chessboard-example)


### PR DESCRIPTION
When I found this blank Examples page with coincidences I thought I could add content from my repos.  
Is this addition welcome?

Let me know if there is something to should fix or improve, thank you!