### PR TITLE
docs: Update missing link about queries

### DIFF
--- a/docs/react-testing-library/migrate-from-enzyme.mdx
+++ b/docs/react-testing-library/migrate-from-enzyme.mdx
@@ -258,7 +258,7 @@ it's not recommended for the reasons stated in this paragraph).
 
 We made some handy query APIs which help you to access the component elements
 very efficiently, and you can see the
-[list of available queries](queries/about) in detail.
+[list of available queries](queries/about.mdx) in detail.
 
 Something else that people have a problem with is that they're not sure which
 query should they use, luckily we have a great page which explains

--- a/docs/react-testing-library/migrate-from-enzyme.mdx
+++ b/docs/react-testing-library/migrate-from-enzyme.mdx
@@ -258,7 +258,7 @@ it's not recommended for the reasons stated in this paragraph).
 
 We made some handy query APIs which help you to access the component elements
 very efficiently, and you can see the
-[list of available queries](dom-testing-library/api-queries.mdx) in detail.
+[list of available queries](queries/about) in detail.
 
 Something else that people have a problem with is that they're not sure which
 query should they use, luckily we have a great page which explains


### PR DESCRIPTION
(dom-testing-library/api-queries.mdx) was leading to a 404 page so I did some research on where it should lead. (dom-testing-library/api) had the (queries/about) under Queries and based on the context of the current sentence, I believe (queries/about) is the page where it should lead.