### PR TITLE
Update api-events.mdx

### DIFF
--- a/docs/dom-testing-library/api-events.mdx
+++ b/docs/dom-testing-library/api-events.mdx
@@ -91,7 +91,7 @@ fireEvent.drop(getByLabelText(/drop files here/i), {
 element in the DOM and the key you want to fire.
 
 ```javascript
-fireEvent.keyDown(domNode, {key: 'Enter', code: 'Enter'})
+fireEvent.keyDown(domNode, {key: 'Enter', code: 'Enter', charCode: 13})
 
 fireEvent.keyDown(domNode, {key: 'A', code: 'KeyA'})
 ```


### PR DESCRIPTION
Since we need ```charCode: 13``` to call ```fireEvent.keyDown()``` using 'Enter' key and a lot of users need to test when 'Enter' key got pressed, I'm proposing this change on this library docs to help more people on this.

reference: https://github.com/testing-library/dom-testing-library/issues/405