### PR TITLE
Update incorrect statement about jsdom in Jest

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -286,7 +286,28 @@ using Create React App without TypeScript, save this to `jsconfig.json` instead.
   }
 }
 ```
+    
+### Jest 27
 
+If you're using a recent version of Jest (27 or later), `jsdom` is no longer the 
+default environment. You can enable `jsdom` globally by editing `jest.config.js`: 
+    
+```diff title="jest.config.js"
+ module.exports = {
++  testEnvironment: 'jest-environment-jsdom',
+   // ... other options ...
+ }
+```
+    
+Or if you only need `jsdom` in some of your tests, you can enable it as and when 
+needed using [docblocks](https://jestjs.io/docs/configuration#testenvironment-string):
+    
+```js 
+ /**
+  * @jest-environment jsdom
+  */
+```
+    
 ### Jest 24 (or lower) and defaults
 
 If you're using the Jest testing framework version 24 or lower with the default
@@ -315,7 +336,7 @@ If you're running your tests in the browser bundled with webpack (or similar)
 then `React Testing Library` should work out of the box for you. However, most
 people using React Testing Library are using it with the Jest testing framework
 with the `testEnvironment` set to `jest-environment-jsdom` (which is the default
-configuration with Jest).
+configuration with Jest 26 and earlier).
 
 `jsdom` is a pure JavaScript implementation of the DOM and browser APIs that
 runs in Node. If you're not using Jest and you would like to run your tests in


### PR DESCRIPTION
[Jest 27 has been released](https://jestjs.io/blog/2021/05/25/jest-27#feature-updates), which no longer defaults to `jest-environment-jsdom`.