### PR TITLE
example-external: add React Testing Library React Dnd Chessboard Example

### DIFF
--- a/docs/example-external.mdx
+++ b/docs/example-external.mdx
@@ -8,6 +8,8 @@ sidebar_label: External Examples
 
 - You can find more React Testing Library examples at
   [react-testing-examples.com](https://react-testing-examples.com/jest-rtl/).
+  
+- [React Testing Library React Dnd Chessboard Example](https://github.com/laststance/react-testing-library-react-dnd-chessboard-example)
 
 ## Playground
 


### PR DESCRIPTION
continue from #930 

I added [React Testing Library React Dnd Chessboard Example](https://github.com/laststance/react-testing-library-react-dnd-chessboard-example) at the `example-external` page.

Thanks!