### PR TITLE
docs: remove Open Collective link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-open_collective: testing-library


### PR DESCRIPTION
We're no longer using Open Collective, so I don't think it makes sense for us to keep the link around.

I'm also planning to focus more time on the docs soon, if so I may PR my own sponsor profile link if others are okay with it (of course we can also add links for other maintainers).