### PR TITLE
docs(user-event): add for pointer events options

### DIFF
--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -557,8 +557,6 @@ test('should paste text in input', () => {
 You can use the `eventInit` if what you're pasting should have `clipboardData`
 (like `files`).
 
-Note: `options` includes [Pointer events options](#pointer-events-options)
-
 ### `specialChars`
 
 A handful set of special characters used in [type](#typeelement-text-options)


### PR DESCRIPTION
This PR adds documentation for the options being introduced with https://github.com/testing-library/user-event/pull/731

- Adds a example and explanation under `click`
- Links to other headings that have these options
- Adds options to events that have these options
- Adds a note to every event that links to the heading with explanation