### PR TITLE
docs(user-event): add example to prepend text with `type`

### DIFF
--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -218,15 +218,8 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 test('prepend text', () => {
-  render(
-    <div>
-      <label htmlFor="my-input">Example:</label>
-      <input id="my-input" type="text" />
-    </div>,
-  )
-
-  const input = screen.getByLabelText(/example/i)
-  userEvent.type(element, 'World!')
+  render(<input defaultValue="World!"/>)
+  const element = screen.getByRole('textbox')
 
   // Prepend text
   element.setSelectionRange(0, 0)

--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -206,6 +206,36 @@ test('delete characters within the selectedRange', () => {
   userEvent.type(input, '{backspace}good')
 
   expect(input).toHaveValue('This is a good example')
+```
+
+By default, `type` appends to the existing text. To prepend text, reset the
+element's selection range and provide the `initialSelectionStart` and
+`initialSelectionEnd` options:
+
+```jsx
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+test('prepend text', () => {
+  render(
+    <div>
+      <label htmlFor="my-input">Example:</label>
+      <input id="my-input" type="text" />
+    </div>,
+  )
+
+  const input = screen.getByLabelText(/example/i)
+  userEvent.type(element, 'World!')
+
+  // Prepend text
+  element.setSelectionRange(0, 0)
+  userEvent.type(element, 'Hello, ', {
+    initialSelectionStart: 0,
+    initialSelectionEnd: 0,
+  })
+
+  expect(element).toHaveValue('Hello, World!')
 })
 ```
 

--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -93,7 +93,9 @@ set `skipPointerEventsCheck` to `true`:
 userEvent.click(elem, undefined, {skipPointerEventsCheck: true})
 ```
 
-The `skipPointerEventsCheck` option can be passed to any pointer related API including:
+The `skipPointerEventsCheck` option can be passed to any pointer related API
+including:
+
 - [dblClick](#dblclickelement-eventinit-options)
 - [hover](#hoverelement-options)
 - [unhover](#unhoverelement-options)


### PR DESCRIPTION
User Interactions > user-event v13 > `type(element, text, [options])`:
- Add an example that shows how to prepend text with `type`.