### PR TITLE
doc: use getBy* in waitFor

### DIFF
--- a/docs/guide-disappearance.mdx
+++ b/docs/guide-disappearance.mdx
@@ -31,9 +31,7 @@ test('movie title appears', async () => {
   // element is initially not present...
 
   // wait for appearance inside an assertion
-  await waitFor(() => {
-    expect(getByText('the lion king')).toBeInTheDocument()
-  })
+  await waitFor(() => getByText('the lion king'))
 })
 ```
 


### PR DESCRIPTION
`expect(queryByText('the lion king')).toBeInTheDocument()` throws an error when element with the text 'the lion king' is not found in the document.
`getByText('the lion king')` throws an error in the same case.
We can simplify expression
```
await waitFor(() => {
  expect(getByText('the lion king')).toBeInTheDocument()
})
```
to
```
await waitFor(() => getByText('the lion king'))
```
as it has the same meaning.