### PR TITLE
docs(jest-native): Explicitly show what's rendered

### DIFF
--- a/docs/ecosystem-jest-native.mdx
+++ b/docs/ecosystem-jest-native.mdx
@@ -13,14 +13,16 @@ npm install --save-dev @testing-library/jest-native
 ```
 
 ```javascript
-;<View>
-  <View testID="not-empty">
-    <Text testID="empty" />
-  </View>
-  <Text testID="visible">Visible Example</Text>
-</View>
+const {queryByTestId} = render(
+  <View>
+    <View testID="not-empty">
+      <Text testID="empty" />
+    </View>
+    <Text testID="visible">Visible Example</Text>
+  </View>,
+)
 
-expect(queryByTestId(baseElement, 'not-empty')).not.toBeEmpty()
+expect(queryByTestId('not-empty')).not.toBeEmpty()
 ```
 
 > Note: when using some of these matchers, you may need to make sure you use a


### PR DESCRIPTION
Gets rid of the odd formatting due to `no-semi`.