### PR TITLE
fix: Use relative links for internal links

### DIFF
--- a/blog/2019-04-25-new-org.mdx
+++ b/blog/2019-04-25-new-org.mdx
@@ -135,14 +135,13 @@ they continue to work as you make changes!
 
 > [Checkout native-testing-library](https://callstack.github.io/react-native-testing-library/)
 
-## [Learn Testing Library](https://testing-library.com/docs/learning)
+## [Learn Testing Library](/docs/learning)
 
 There's been a LOT of activity around the Testing Library principles and tools
 in the content space. We do have
-[a page that lists learning materials](https://testing-library.com/docs/learning),
-and more gets added to it daily. If you know of blog posts, YouTube videos,
-courses, or anything else about the Testing Library family of tools, please
-contribute to the list!
+[a page that lists learning materials](/docs/learning), and more gets added to
+it daily. If you know of blog posts, YouTube videos, courses, or anything else
+about the Testing Library family of tools, please contribute to the list!
 
 > [Contribute to the learning materials page](https://github.com/testing-library/testing-library-docs/edit/main/docs/learning.mdx)
 

--- a/docs/angular-testing-library/api.mdx
+++ b/docs/angular-testing-library/api.mdx
@@ -353,12 +353,10 @@ await navigate('details/3')
 ### `...queries`
 
 The most important feature of `render` is that the queries from
-[DOM Testing Library](https://testing-library.com/docs/dom-testing-library) are
-automatically returned with their first argument bound to the component under
-test.
+[DOM Testing Library](/docs/dom-testing-library/intro) are automatically
+returned with their first argument bound to the component under test.
 
-See [Queries](https://testing-library.com/docs/dom-testing-library/api-queries)
-for a complete list.
+See [Queries](/docs/dom-testing-library/api-queries) for a complete list.
 
 **example**:
 

--- a/docs/cypress-testing-library/intro.mdx
+++ b/docs/cypress-testing-library/intro.mdx
@@ -24,7 +24,7 @@ import '@testing-library/cypress/add-commands';
 
 You can now use all of `DOM Testing Library`'s `findBy`, `findAllBy`, `queryBy`
 and `queryAllBy` commands off the global `cy` object.
-[See the `DOM Testing Library` docs for reference](https://testing-library.com/docs/dom-testing-library/api-queries).
+[See the `DOM Testing Library` docs for reference](/docs/dom-testing-library/api-queries).
 
 > Note: the `get*` queries are not supported because for reasonable Cypress
 > tests you need retryability and `find*` queries already support that. `query*`


### PR DESCRIPTION
Last 404 was to `/docs/dom-testing-library`. Found by listing all internal links using https://gist.github.com/eps1lon/29e4c57c546a4aef4701913e0237b831

Closes https://github.com/testing-library/testing-library-docs/issues/960