### PR TITLE
Fix broken link in cypress-testing-library intro

### DIFF
--- a/docs/cypress-testing-library/intro.mdx
+++ b/docs/cypress-testing-library/intro.mdx
@@ -24,7 +24,7 @@ import '@testing-library/cypress/add-commands';
 
 You can now use all of `DOM Testing Library`'s `findBy`, `findAllBy`, `queryBy`
 and `queryAllBy` commands off the global `cy` object.
-[See the `DOM Testing Library` docs for reference](/docs/dom-testing-library/api-queries).
+[See the `About queries` docs for reference](/docs/queries/about).
 
 > Note: the `get*` queries are not supported because for reasonable Cypress
 > tests you need retryability and `find*` queries already support that. `query*`


### PR DESCRIPTION
This PR fixes a 404 link pointing to `DOM Testing Library` docs by replacing it with a reference to `About queries` section (which I believe was the intention, as while the text says `DOM testing library docs` the link points to an URL ending with `api-queries`).