### PR TITLE
chore: update algolia credentials

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -344,7 +344,8 @@ module.exports = {
       },
     },
     algolia: {
-      apiKey: 'bda29e6557dc5be1ce5c05f2dbff8f33',
+      appId: 'TUPO88CFRP',
+      apiKey: 'b232f752ed8fb44d7ff8e7883aa64668',
       indexName: 'testing-library',
     },
     gtag: {


### PR DESCRIPTION
Since there's no migration guide for docusaurus v2 yet, I read the [v1 migration guide](https://v1.docusaurus.io/blog/2021/11/05/algolia-migration) and updated according to it and according to [algolia's recommendations](https://docsearch.algolia.com/docs/migrating-from-legacy/).

I tested this one locally and search seems to work properly.

Resolves https://github.com/testing-library/testing-library-docs/issues/965

