### PR TITLE
fix: broken queries link in angular api

### DIFF
--- a/docs/angular-testing-library/api.mdx
+++ b/docs/angular-testing-library/api.mdx
@@ -356,7 +356,7 @@ The most important feature of `render` is that the queries from
 [DOM Testing Library](/docs/dom-testing-library/intro) are automatically
 returned with their first argument bound to the component under test.
 
-See [Queries](/docs/dom-testing-library/api-queries) for a complete list.
+See [Queries](queries/about.mdx) for a complete list.
 
 **example**:
 


### PR DESCRIPTION
Similar to https://github.com/testing-library/testing-library-docs/pull/745