### PR TITLE
docs: remove outdated info on Jest default env

### DIFF
--- a/docs/dom-testing-library/setup.mdx
+++ b/docs/dom-testing-library/setup.mdx
@@ -10,7 +10,6 @@ people using `DOM Testing Library` are using it with
 [the Jest testing framework](https://jestjs.io/) with the `testEnvironment` set
 to
 [`jest-environment-jsdom`](https://www.npmjs.com/package/jest-environment-jsdom)
-(which is the default configuration with Jest).
 
 ## Using Without Jest
 


### PR DESCRIPTION
JSDOM is no longer a default environment since Jest 27: https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults