### PR TITLE
Update vue-testing-library examples' links to point to `main` branch

### DIFF
--- a/docs/vue-testing-library/examples.mdx
+++ b/docs/vue-testing-library/examples.mdx
@@ -99,8 +99,8 @@ You'll find examples of testing with different libraries in
 
 Some included are:
 
-- [`vuex`](https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vuex.js)
-- [`vue-router`](https://github.com/testing-library/vue-testing-library/tree/master/src/__tests__/vue-router.js)
-- [`vee-validate`](https://github.com/testing-library/vue-testing-library/tree/master/src/__tests__/validate-plugin.js)
-- [`vue-i18n`](https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/translations-vue-i18n.js)
-- [`vuetify`](https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vuetify.js)
+- [`vuex`](https://github.com/testing-library/vue-testing-library/blob/main/src/__tests__/vuex.js)
+- [`vue-router`](https://github.com/testing-library/vue-testing-library/tree/main/src/__tests__/vue-router.js)
+- [`vee-validate`](https://github.com/testing-library/vue-testing-library/tree/main/src/__tests__/validate-plugin.js)
+- [`vue-i18n`](https://github.com/testing-library/vue-testing-library/blob/main/src/__tests__/translations-vue-i18n.js)
+- [`vuetify`](https://github.com/testing-library/vue-testing-library/blob/main/src/__tests__/vuetify.js)


### PR DESCRIPTION
Examples of vue-testing-library had links pointing to `master` branch but the branch is renamed to `main` now. Though GitHub redirects to the renamed branch, it'd be good to have this updated and save a redirect :)