### PR TITLE
fix: svelte client-side component api link

### DIFF
--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -34,7 +34,7 @@ const {results} = render(YourComponent, {ComponentOptions}, {RenderOptions})
 
 These are the options you pass when instantiating your Svelte `Component`.
 Please refer to the
-[Client-side component API](https://svelte.dev/docs#Client-side_component_API).
+[Client-side component API](https://svelte.dev/docs#run-time-client-side-component-api-creating-a-component).
 
 📝 If the only option you're passing in is `props`, then you can just pass them
 in directly.


### PR DESCRIPTION
Fixes the link to the Svelte component's _Client-Side Component API_ documentation.
To be: https://svelte.dev/docs#run-time-client-side-component-api-creating-a-component