### PR TITLE
Update relative imports CRA note

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -252,10 +252,6 @@ Jest `moduleDirectories` option.
 This will make all the `.js` files in the test-utils directory importable
 without `../`.
 
-> **Note**
->
-> This can't be used with Create React App.
-
 ```diff title="my-component.test.js"
 - import { render, fireEvent } from '../test-utils';
 + import { render, fireEvent } from 'test-utils';


### PR DESCRIPTION
Jest test files without using relative imports in CRA in now allowed with the ability to configure [absolute imports](https://create-react-app.dev/docs/importing-a-component/#absolute-imports). Removing note section.