### PR TITLE
feat: document user-event v14

### DIFF
--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -1,6 +1,6 @@
 ---
 id: ecosystem-user-event
-title: user-event
+title: user-event v13
 ---
 
 import Tabs from '@theme/Tabs'

--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -10,6 +10,10 @@ import TabItem from '@theme/TabItem'
 advanced simulation of browser interactions than the built-in
 [`fireEvent`](dom-testing-library/api-events.mdx#fireevent) method.
 
+> This page describes `user-event@13.5.0`.
+If you are starting or actively working on a project,
+we recommend to use [`user-event@14.0.0-beta`](user-event/intro) instead, as it includes important bug fixes and new features.  
+
 ## Installation
 
   <Tabs defaultValue="npm" values={[{ label: 'npm', value: 'npm' }, { label: 'Yarn', value: 'yarn' }]}>

--- a/docs/user-event/api-clipboard.mdx
+++ b/docs/user-event/api-clipboard.mdx
@@ -1,0 +1,49 @@
+---
+id: clipboard
+title: Clipboard
+---
+
+Note that the
+[Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) is
+usually not available outside of secure context.  
+To enable testing of workflows involving the clipboard,
+[`userEvent.setup()`](setup) replaces `window.navigator.clipboard` with a stub.
+
+## copy()
+
+```ts
+copy(): Promise<DataTransfer|undefined>
+```
+
+Copy the current selection.
+
+If [`writeToClipboard`](options#writetoclipboard) is `true`, this will also
+write the data to the `Clipboard`.
+
+## cut()
+
+```ts
+cut(): Promise<DataTransfer|undefined>
+```
+
+Cut the current selection.
+
+If [`writeToClipboard`](options#writetoclipboard) is `true`, this will also
+write the data to the `Clipboard`.
+
+When performed in editable context, it removes the selected content from the
+document.
+
+## paste()
+
+```ts
+paste(clipboardData?: DataTransfer|string): Promise<void>
+```
+
+Paste data into the document.
+
+When called without `clipboardData`, the content to be pasted is read from the
+`Clipboard`.
+
+When performed in editable context, the pasted content is inserted into to the
+document.

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -1,0 +1,83 @@
+---
+id: convenience
+title: Convenience APIs
+---
+
+The following APIs are shortcuts for equivalent calls to the underlying
+[`pointer()`](pointer) and [`keyboard()`](keyboard) APIs.
+
+## Clicks
+
+### click()
+
+```ts
+click(element: Element): Promise<void>
+```
+
+```js
+pointer([{target: element}, {keys: '[MouseLeft]', target: element}])
+```
+
+The first action might be skipped per [`skipHover`](options#skiphover).
+
+### dblClick()
+
+```ts
+dblClick(element: Element): Promise<void>
+```
+
+```js
+pointer([{target: element}, {keys: '[MouseLeft][MouseLeft]', target: element}])
+```
+
+### tripleClick()
+
+```ts
+tripleClick(element: Element): Promise<void>
+```
+
+```js
+pointer([
+  {target: element},
+  {keys: '[MouseLeft][MouseLeft][MouseLeft]', target: element},
+])
+```
+
+## Mouse movement
+
+### hover()
+
+```ts
+hover(element: Element): Promise<void>
+```
+
+```js
+pointer({target: element})
+```
+
+### unhover()
+
+```ts
+hover(element: Element): Promise<void>
+```
+
+```js
+pointer({target: element.ownerDocument.body})
+```
+
+## Keyboard
+
+### tab()
+
+```ts
+tab(options: {shift?: boolean})
+```
+
+```js
+// without shift
+keyboard('{Tab}')
+// with shift=true
+keyboard('{Shift>}{Tab}{/Shift}')
+// with shift=false
+keyboard('[/ShiftLeft][/ShiftRight]{Tab}')
+```

--- a/docs/user-event/api-keyboard.mdx
+++ b/docs/user-event/api-keyboard.mdx
@@ -79,5 +79,5 @@ keys.
 > Future versions might try to interpolate the modifiers needed to reach a
 > printable key on the keyboard. E.g. Automatically pressing `{Shift}` when
 > CapsLock is not active and `A` is referenced. If you don't wish this behavior,
-> you can deactivate the [`autoModify`](options#automodify) option to opt of out
+> you can deactivate the [`autoModify`](options#automodify) option to opt out
 > of this non-breaking change.

--- a/docs/user-event/api-keyboard.mdx
+++ b/docs/user-event/api-keyboard.mdx
@@ -1,0 +1,83 @@
+---
+id: keyboard
+title: Keyboard
+---
+
+```ts
+keyboard(input: KeyboardInput): Promise<void>
+```
+
+The `keyboard` API allows to simulate interactions with a keyboard. It accepts a
+`string` describing the key actions.
+
+Keystrokes can be described:
+
+- Per printable character
+  ```js
+  keyboard('foo') // translates to: f, o, o
+  ```
+  The brackets `{` and `[` are used as special character and can be referenced
+  by doubling them.
+  ```js
+  keyboard('{{a[[') // translates to: {, a, [
+  ```
+- Per
+  [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)
+
+  ```js
+  keyboard('{Shift}{f}{o}{o}') // translates to: Shift, f, o, o
+  ```
+
+  This does not keep any key pressed. So `Shift` will be lifted before pressing
+  `f`.
+
+  Characters with special meaning inside the key descriptor can be escaped by
+  prefixing them with a backslash `\`.
+
+  ```js
+  keyboard('{}}') // translates to: }
+  ```
+
+- Per
+  [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)
+  ```js
+  keyboard('[ShiftLeft][KeyF][KeyO][KeyO]') // translates to: Shift, f, o, o
+  ```
+
+Keys can be kept pressed by adding a `>` to the end of the descriptor.  
+If this should result in repeated `keydown` events, you can add the number of
+repetitions.  
+If the key should also be released after this, add a slash `/` to the end of the
+descriptor.
+
+```js
+keyboard('{a>}') // press a without releasing it
+keyboard('{a>5}') // press a without releasing it and trigger 5 keydown
+keyboard('{a>5/}') // press a for 5 keydown and then release it
+```
+
+A previously pressed key can be lifted by prefixing the descriptor with `/`.
+
+```js
+keyboard('{/a}') // release a previously pressed a
+```
+
+This allows to simulate key combinations.
+
+```js
+keyboard('{Shift>}A{/Shift}') // translates to: Shift(down), A, Shift(up)
+```
+
+The mapping of `key` to `code` is performed by a
+[default key map](https://github.com/testing-library/user-event/blob/beta/src/keyboard/keyMap.ts)
+portraying a "default" US-keyboard. You can provide your own local keyboard
+mapping per [`keyboardMap`](options#keyboardMap) option.
+
+Currently the different `key` meanings of single keys are treated as different
+keys.
+
+> Future versions might try to interpolate the modifiers needed to reach a
+> printable key on the keyboard. E.g. Automatically pressing `{Shift}` when
+> CapsLock is not active and `A` is referenced. If you don't wish this behavior,
+> you can deactivate the [`autoModify`](options#autoModify) option to opt of out
+> of this non-breaking change.

--- a/docs/user-event/api-keyboard.mdx
+++ b/docs/user-event/api-keyboard.mdx
@@ -16,7 +16,7 @@ Keystrokes can be described:
   ```js
   keyboard('foo') // translates to: f, o, o
   ```
-  The brackets `{` and `[` are used as special character and can be referenced
+  The brackets `{` and `[` are used as special characters and can be referenced
   by doubling them.
   ```js
   keyboard('{{a[[') // translates to: {, a, [

--- a/docs/user-event/api-keyboard.mdx
+++ b/docs/user-event/api-keyboard.mdx
@@ -71,7 +71,7 @@ keyboard('{Shift>}A{/Shift}') // translates to: Shift(down), A, Shift(up)
 The mapping of `key` to `code` is performed by a
 [default key map](https://github.com/testing-library/user-event/blob/beta/src/keyboard/keyMap.ts)
 portraying a "default" US-keyboard. You can provide your own local keyboard
-mapping per [`keyboardMap`](options#keyboardMap) option.
+mapping per [`keyboardMap`](options#keyboardmap) option.
 
 Currently the different `key` meanings of single keys are treated as different
 keys.
@@ -79,5 +79,5 @@ keys.
 > Future versions might try to interpolate the modifiers needed to reach a
 > printable key on the keyboard. E.g. Automatically pressing `{Shift}` when
 > CapsLock is not active and `A` is referenced. If you don't wish this behavior,
-> you can deactivate the [`autoModify`](options#autoModify) option to opt of out
+> you can deactivate the [`autoModify`](options#automodify) option to opt of out
 > of this non-breaking change.

--- a/docs/user-event/api-pointer.mdx
+++ b/docs/user-event/api-pointer.mdx
@@ -14,9 +14,7 @@ accepts a single pointer action or an array of them.
 type PointerInput = PointerActionInput | Array<PointerActionInput>
 ```
 
-## No-layout environment
-
-Our primary target audience tests per `jest` in a `jsdom` environment and there
+> Our primary target audience tests per `jest` in a `jsdom` environment and there
 is no layout in `jsdom`. This means that different from your browser the
 elements don't exist in a specific position, layer and size.  
 We don't try to determine if the pointer action you describe is possible at that

--- a/docs/user-event/api-pointer.mdx
+++ b/docs/user-event/api-pointer.mdx
@@ -1,0 +1,122 @@
+---
+id: pointer
+title: Pointer
+---
+
+```ts
+pointer(input: PointerInput): Promise<void>
+```
+
+The `pointer` API allows to simulate interactions with pointer devices. It
+accepts a single pointer action or an array of them.
+
+```ts
+type PointerInput = PointerActionInput | Array<PointerActionInput>
+```
+
+## No-layout environment
+
+Our primary target audience tests per `jest` in a `jsdom` environment and there
+is no layout in `jsdom`. This means that different from your browser the
+elements don't exist in a specific position, layer and size.  
+We don't try to determine if the pointer action you describe is possible at that
+position in your layout.
+
+## Pointer action
+
+There are to types of actions: press and move.
+
+### <a name="press" href="#"/>Pressing a button or touching the screen
+
+A pointer action is a press action if it defines a key to be pressed, to be
+released, or both.
+
+```js
+pointer({keys: '[MouseLeft]'})
+```
+
+You can declare multiple press actions (on the same position) at once which will
+be resolved to multiple actions internally. If you don't need to declare any
+other properties you can also just supply the `keys` string.
+
+```js
+pointer({keys: '[MouseLeft][MouseRight]'})
+// or
+pointer('[MouseLeft][MouseRight]')
+```
+
+For pressing a button without releasing it, the button name is suffixed with
+`>`.  
+For just releasing a previously pressed button, the tag is started with `/`.
+
+```js
+pointer('[MouseLeft>]') // press the left mouse button
+pointer('[/MouseLeft]') // release the left mouse button
+```
+
+Which button are available depends on the [`pointerMap`](options#pointerMap).
+
+### <a name="move" href="#"/>Moving a pointer
+
+Every pointer action that is not a press action describes a pointer movement.
+
+You can declare which pointer is moved per `pointerName` property. This defaults
+to `mouse`.
+
+Note that the `mouse` pointer (`pointerId: 1`) is also the only pointer that
+always exists and has a position. A `touch` pointer only exists while the screen
+is touched and receives a new `pointerId` every time. For these we therefore use
+the "button" name from the press action as `pointerName`.
+
+```js
+pointer([
+  // touch the screen at element1
+  {keys: '[TouchA>]', target: element1},
+  // move the touch pointer to element2
+  {pointerName: 'TouchA', target: element2},
+  // release the touch pointer at the last position (element2)
+  {keys: '[/TouchA]'},
+])
+```
+
+## Pointer position
+
+### PointerTarget
+
+```ts
+interface PointerTarget {
+  target: Element
+  coords?: PointerCoords
+}
+```
+
+The `PointerTarget` props allows to describe the position of the pointer on the
+document.  
+The `coords` you provide are applied as-is to the resulting
+[`MouseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) and
+can be omitted.  
+The `target` should be the element receiving the pointer input in the browser.
+This is the topmost element that can receive pointer event at those coordinates.
+
+### SelectionTarget
+
+```ts
+interface SelectionTarget {
+  node?: Node
+  offset?: number
+}
+```
+
+Pointer actions can alter the selection in the document.  
+In the browser every pointer position corresponds with a DOM position. This is a
+DOM node and a DOM offset which usually translates to the character closest to
+the pointer position.  
+As all character in a no-layout environment are in the same layout position we
+assume a pointer position to be closest to the last descendant of the pointer
+`target`.
+
+If you provide `offset`, we assume the pointer position to be closest to the
+`offset-th` character of `target.textContent`.
+
+If you also provide `node`, we treat `node` and `offset` as the exact DOM
+position to be used for any selection.

--- a/docs/user-event/api-pointer.mdx
+++ b/docs/user-event/api-pointer.mdx
@@ -118,3 +118,21 @@ If you provide `offset`, we assume the pointer position to be closest to the
 
 If you also provide `node`, we treat `node` and `offset` as the exact DOM
 position to be used for any selection.
+
+```jsx
+// element: <div><span>foo</span><span>bar</span></div>
+// | marking the cursor.
+// [ ] marking a selection.
+
+pointer({target: element, offset: 2, keys: '[MouseLeft]'})
+// => <div><span>fo|o</span><span>bar</span></div>
+
+pointer([
+  {target: element, offset: 2, keys: '[MouseLeft>]'},
+  {offset: 5},
+])
+// => <div><span>fo[o</span><span>ba]r</span></div>
+
+pointer({target: element, node: element, offset: 1, keys: '[MouseLeft]'})
+// => <div><span>foo</span>|<span>bar</span></div>
+```

--- a/docs/user-event/api-pointer.mdx
+++ b/docs/user-event/api-pointer.mdx
@@ -52,7 +52,7 @@ pointer('[MouseLeft>]') // press the left mouse button
 pointer('[/MouseLeft]') // release the left mouse button
 ```
 
-Which button are available depends on the [`pointerMap`](options#pointerMap).
+Which button are available depends on the [`pointerMap`](options#pointermap).
 
 ### <a name="move" href="#"/>Moving a pointer
 

--- a/docs/user-event/api-pointer.mdx
+++ b/docs/user-event/api-pointer.mdx
@@ -22,7 +22,7 @@ position in your layout.
 
 ## Pointer action
 
-There are to types of actions: press and move.
+There are two types of actions: press and move.
 
 ### <a name="press" href="#"/>Pressing a button or touching the screen
 

--- a/docs/user-event/api-pointer.mdx
+++ b/docs/user-event/api-pointer.mdx
@@ -43,7 +43,7 @@ pointer({keys: '[MouseLeft][MouseRight]'})
 pointer('[MouseLeft][MouseRight]')
 ```
 
-For pressing a button without releasing it, the button name is suffixed with
+In order to press a button without releasing it, the button name is suffixed with
 `>`.  
 For just releasing a previously pressed button, the tag is started with `/`.
 
@@ -52,7 +52,7 @@ pointer('[MouseLeft>]') // press the left mouse button
 pointer('[/MouseLeft]') // release the left mouse button
 ```
 
-Which button are available depends on the [`pointerMap`](options#pointermap).
+Which buttons are available depends on the [`pointerMap`](options#pointermap).
 
 ### <a name="move" href="#"/>Moving a pointer
 
@@ -63,7 +63,7 @@ to `mouse`.
 
 Note that the `mouse` pointer (`pointerId: 1`) is also the only pointer that
 always exists and has a position. A `touch` pointer only exists while the screen
-is touched and receives a new `pointerId` every time. For these we therefore use
+is touched and receives a new `pointerId` every time. For these pointers, we use
 the "button" name from the press action as `pointerName`.
 
 ```js

--- a/docs/user-event/api-utility.mdx
+++ b/docs/user-event/api-utility.mdx
@@ -127,6 +127,17 @@ Type into an input element.
 1. Unless [`skipAutoClose`](options#skipautoclose) is `true`, release all
    pressed keys.
 
+```jsx
+test('type into an input field', async () => {
+  render(<input defaultValue="Hello,"/>)
+  const input = screen.getByRole('textbox')
+
+  await userEvent.type(input, ' World!')
+
+  expect(input).toHaveValue('Hello, World!')
+})
+```
+
 ## upload()
 
 ```ts

--- a/docs/user-event/api-utility.mdx
+++ b/docs/user-event/api-utility.mdx
@@ -3,7 +3,7 @@ id: utility
 title: Utility APIs
 ---
 
-The following APIs don't have one-to-one equivalent in a real user
+The following APIs don't have one-to-one equivalents in a real user
 interaction.  
 Their behavior is therefore an interpretation how the "perceived" user
 interaction might be translated to actual events on the DOM.

--- a/docs/user-event/api-utility.mdx
+++ b/docs/user-event/api-utility.mdx
@@ -1,0 +1,179 @@
+---
+id: utility
+title: Utility APIs
+---
+
+The following APIs don't have one-to-one equivalent in a real user
+interaction.  
+Their behavior is therefore an interpretation how the "perceived" user
+interaction might be translated to actual events on the DOM.
+
+## clear()
+
+```ts
+clear(element: Element): Promise<void>
+```
+
+This API can be used to easily clear an editable element.
+
+1. Focus element
+1. Select all contents as per browser menu
+1. Delete contents as per browser menu
+
+```jsx
+test('clear', async () => {
+  render(<textarea value="Hello, World!" />)
+
+  await userEvent.clear(screen.getByRole('textbox'))
+
+  expect(screen.getByRole('textbox')).toHaveAttribute('value', '')
+})
+```
+
+The `Promise` is rejected if the element can not be focused or contents can not
+be selected.
+
+## <a name="selectoptions"/><a name="deselectoptions"/> selectOptions(), deselectOptions()
+
+```ts
+selectOptions(
+    element: Element,
+    values: HTMLElement | HTMLElement[] | string[] | string,
+): Promise<void>
+deselectOptions(
+    element: Element,
+    values: HTMLElement | HTMLElement[] | string[] | string,
+): Promise<void>
+```
+
+Select/deselect the given options in an
+[HTMLSelectElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement)
+or
+[listbox](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role).
+
+The `values` parameter can refer to an option per its value, HTML content or
+just provide the element. It also accepts an array of these.
+
+> Selecting multiple options and/or deselecting options of `HTMLSelectElement`
+> is only possible if
+> [multiple](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attr-multiple)
+> is specified.
+
+```jsx
+test('selectOptions', async () => {
+  render(
+    <select multiple>
+      <option value="1">A</option>
+      <option value="2">B</option>
+      <option value="3">C</option>
+    </select>,
+  )
+
+  await userEvent.selectOptions(screen.getByRole('listbox'), ['1', 'C'])
+
+  expect(screen.getByRole('option', {name: 'A'}).selected).toBe(true)
+  expect(screen.getByRole('option', {name: 'B'}).selected).toBe(false)
+  expect(screen.getByRole('option', {name: 'C'}).selected).toBe(true)
+})
+```
+
+```jsx
+test('deselectOptions', async () => {
+  render(
+    <select multiple>
+      <option value="1">A</option>
+      <option value="2" selected>
+        B
+      </option>
+      <option value="3">C</option>
+    </select>,
+  )
+
+  await userEvent.deselectOptions(screen.getByRole('listbox'), '2')
+
+  expect(screen.getByText('B').selected).toBe(false)
+})
+```
+
+Note that this API triggers pointer events and is therefore subject to
+[pointerEventsCheck](options#pointereventscheck).
+
+## type()
+
+```ts
+type(
+    element: Element,
+    text: KeyboardInput,
+    options?: {
+        skipClick?: boolean
+        skipAutoClose?: boolean
+        initialSelectionStart?: number
+        initialSelectionEnd?: number
+    }
+): Promise<void>
+```
+
+Type into an input element.
+
+> You should use [`keyboard()`](keyboard) if you want to just simulate pressing
+> buttons on the keyboard.  
+> You can use `type()` if you just want to conveniently insert some text into an
+> input field or textarea.
+
+1. Unless [`skipClick`](options#skipclick) is `true`, click the element.
+1. If `initialSelectionStart` is set, set the selection on the element. If
+   `initialSelectionEnd` is not set, this results in a collapsed selection.
+1. Type the given `text` per [`keyboard()`](keyboard).
+1. Unless [`skipAutoClose`](options#skipautoclose) is `true`, release all
+   pressed keys.
+
+## upload()
+
+```ts
+upload(
+    element: HTMLElement,
+    fileOrFiles: File | File[],
+): Promise<void>
+```
+
+Change a file input as if a user clicked it and selected files in the resulting
+file upload dialog.
+
+```jsx
+test('upload file', async () => {
+  render(
+    <div>
+      <label htmlFor="file-uploader">Upload file:</label>
+      <input id="file-uploader" type="file" />
+    </div>,
+  )
+  const file = new File(['hello'], 'hello.png', {type: 'image/png'})
+  const input = screen.getByLabelText(/upload file/i)
+
+  await userEvent.upload(input, file)
+
+  expect(input.files[0]).toBe(file)
+  expect(input.files.item(0)).toBe(file)
+  expect(input.files).toHaveLength(1)
+})
+
+test('upload multiple files', async () => {
+  render(
+    <div>
+      <label htmlFor="file-uploader">Upload file:</label>
+      <input id="file-uploader" type="file" multiple />
+    </div>,
+  )
+  const files = [
+    new File(['hello'], 'hello.png', {type: 'image/png'}),
+    new File(['there'], 'there.png', {type: 'image/png'}),
+  ]
+  const input = screen.getByLabelText(/upload file/i)
+
+  await userEvent.upload(input, files)
+
+  expect(input.files).toHaveLength(2)
+  expect(input.files[0]).toBe(files[0])
+  expect(input.files[1]).toBe(files[1])
+})
+```

--- a/docs/user-event/api-utility.mdx
+++ b/docs/user-event/api-utility.mdx
@@ -22,11 +22,11 @@ This API can be used to easily clear an editable element.
 
 ```jsx
 test('clear', async () => {
-  render(<textarea value="Hello, World!" />)
+  render(<textarea defaultValue="Hello, World!" />)
 
   await userEvent.clear(screen.getByRole('textbox'))
 
-  expect(screen.getByRole('textbox')).toHaveAttribute('value', '')
+  expect(screen.getByRole('textbox')).toHaveValue('')
 })
 ```
 

--- a/docs/user-event/install.mdx
+++ b/docs/user-event/install.mdx
@@ -1,0 +1,36 @@
+---
+id: install
+title: Installation
+---
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+<Tabs defaultValue="npm" values={[
+    { label: 'npm', value: 'npm' },
+    { label: 'Yarn', value: 'yarn' },
+]}>
+<TabItem value="npm">
+
+```sh
+npm install --save-dev @testing-library/user-event@^14.0.0-beta
+```
+
+</TabItem>
+<TabItem value="yarn">
+
+```sh
+yarn add --dev @testing-library/user-event@^14.0.0-beta
+```
+
+</TabItem>
+</Tabs>
+
+Note that `@testing-library/user-event` requires `@testing-library/dom`.
+
+If you use one of the
+[framework wrappers](../dom-testing-library/install#wrappers), it is important
+that `@testing-library/dom` is resolved to the same installation required by the
+framework wrapper of your choice.  
+Usually this means that if you use one of the framework wrappers, you should not
+add `@testing-library/dom` to your project dependencies.

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -57,7 +57,7 @@ test('trigger some awesome feature when clicking the button', async () => {
 function setup(jsx) {
     return {
         user: userEvent.setup(),
-        ...render(<MyComponent/>),
+        ...render(jsx),
     }
 }
 

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -3,9 +3,9 @@ id: intro
 title: Introduction
 ---
 
-[`user-event`][gh] is a companion library for Testing Library that simulates
-user interactions by dispatching the events that would happen if the interaction
-took place in a browser.
+[`user-event`](https://github.com/testing-library/user-event)
+is a companion library for Testing Library that simulates user interactions by
+dispatching the events that would happen if the interaction took place in a browser.
 
 While most examples with `user-event` are for `React`, the library can be used
 with any framework as long as there is a DOM.

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -7,6 +7,14 @@ title: Introduction
 is a companion library for Testing Library that simulates user interactions by
 dispatching the events that would happen if the interaction took place in a browser.
 
+> These docs describe `user-event@14.0.0-beta`.
+This is still a pre-release and might be subject to breaking changes
+if they should be deemed necessary in the light of feedback we receive for this version.
+All planned breaking changes are implemented though.  
+If you are starting or actively working on a project,
+we recommend to use this pre-release, as it includes important bug fixes and new features.  
+You can find the docs for `user-event@13.5.0` [here](ecosystem-user-event).
+
 While most examples with `user-event` are for `React`, the library can be used
 with any framework as long as there is a DOM.
 

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -10,10 +10,10 @@ dispatching the events that would happen if the interaction took place in a brow
 > These docs describe `user-event@14.0.0-beta`.
 This is still a pre-release and might be subject to breaking changes
 if they should be deemed necessary in the light of feedback we receive for this version.
-All planned breaking changes are implemented though.  
+All planned breaking changes are already implemented though.  
 If you are starting or actively working on a project,
 we recommend to use this pre-release, as it includes important bug fixes and new features.  
-You can find the docs for `user-event@13.5.0` [here](ecosystem-user-event).
+You can find the docs for `user-event@13.5.0` [here](../ecosystem-user-event).
 
 While most examples with `user-event` are for `React`, the library can be used
 with any framework as long as there is a DOM.

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -1,0 +1,46 @@
+---
+id: intro
+title: Introduction
+---
+
+[`user-event`][gh] is a companion library for Testing Library that simulates
+user interactions by dispatching the events that would happen if the interaction
+took place in a browser.
+
+While most examples with `user-event` are for `React`, the library can be used
+with any framework as long as there is a DOM.
+
+## Difference to `fireEvent`
+
+The built-in [`fireEvent`](dom-testing-library/api-events.mdx#fireevent) is a
+utility to easier dispatch events.  
+It dispatches exactly the event you tell it to and just those - even if that
+exact event never had been dispatched in a real interaction in a browser.
+
+`user-event` on the other hand dispatches the events like they would happen if a
+user interacted with the document.  
+That might lead to the same event you previously dispatched per `fireEvent`
+directly, but it also might catch bugs that make it impossible for a user to
+trigger said event.  
+This is
+[why you should use `user-event`](https://ph-fritsche.github.io/blog/post/why-userevent)
+to test interaction with your components.
+
+## Writing tests with `userEvent`
+
+We recommend to use [`userEvent.setup()`](setup) when rendering your component
+and inline that rendering and setup in your test or use a setup function.  
+We discourage rendering or using any `userEvent` functions outside of the test
+itself - e.g. in a `before`/`after` hook - for reasons described in
+["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing).
+
+```js
+test('trigger some awesome feature when clicking the button', async () => {
+    const user = userEvent.setup()
+    render(<MyComponent/>)
+
+    await user.click(screen.getByRole('button', name: /click me!/))
+
+    // ...assertions...
+})
+```

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -44,3 +44,17 @@ test('trigger some awesome feature when clicking the button', async () => {
     // ...assertions...
 })
 ```
+
+```js
+function setup(jsx) {
+    return {
+        user: userEvent.setup(),
+        ...render(<MyComponent/>),
+    }
+}
+
+test('render with a setup function', async () => {
+    const { user } = setup(<MyComponent/>)
+    // ...
+})
+```

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -22,14 +22,14 @@ with any framework as long as there is a DOM.
 
 The built-in [`fireEvent`](dom-testing-library/api-events.mdx#fireevent) is a
 utility to easier dispatch events.  
-It dispatches exactly the event you tell it to and just those - even if that
-exact event never had been dispatched in a real interaction in a browser.
+It dispatches exactly the events you tell it to and just those - even if those
+exact events never had been dispatched in a real interaction in a browser.
 
 `user-event` on the other hand dispatches the events like they would happen if a
 user interacted with the document.  
-That might lead to the same event you previously dispatched per `fireEvent`
+That might lead to the same events you previously dispatched per `fireEvent`
 directly, but it also might catch bugs that make it impossible for a user to
-trigger said event.  
+trigger said events.  
 This is
 [why you should use `user-event`](https://ph-fritsche.github.io/blog/post/why-userevent)
 to test interaction with your components.

--- a/docs/user-event/options.mdx
+++ b/docs/user-event/options.mdx
@@ -3,6 +3,9 @@ id: options
 title: Options
 ---
 
+The following options allow to adjust the behavior of `user-event` APIs.
+They can be applied per [`setup()`](setup).
+
 ### applyAccept
 
 When using [`upload()`](utility#upload), automatically discard files that don't

--- a/docs/user-event/options.mdx
+++ b/docs/user-event/options.mdx
@@ -1,0 +1,118 @@
+---
+id: options
+title: Options
+---
+
+### applyAccept
+
+When using [`upload()`](utility#upload), automatically discard files that don't
+match an `accept` property if such property exists on the element.
+
+`default`: `true`
+
+### autoModify
+
+We intend to automatically apply modifier keys for printable characters in the
+future.  
+I.e. `A` implying `{Shift>}a{/Shift}` if caps lock is not active.
+
+This options allows you to opt out of this change in foresight.  
+The feature therefore will not constitute a breaking change.
+
+`default`: `true`
+
+### delay
+
+Between some subsequent inputs like typing a series of characters the code
+execution is delayed per `setTimeout` for (at least) `delay` seconds.
+
+This moves the next changes at least to the next macro task and allows other
+(asynchronous) code to run between events.
+
+`null` prevents `setTimeout` from being called.
+
+`default`: `0`
+
+### document
+
+The document.
+
+This defaults to the owner document of an element if an API is called
+[directly](setup#direct-api) with an element and without setup. Otherwise it
+falls back to the global document.
+
+`default`: `element.ownerDocument ?? global.document`
+
+### keyboardMap
+
+An array of keyboard keys the keyboard device consists of.
+
+This allows to plug in different layouts / localizations.
+
+`default`:
+[A "standard" US-104-QWERTY keyboard.](https://github.com/testing-library/user-event/blob/beta/src/keyboard/keyMap.ts)
+
+### pointerEventsCheck
+
+The pointer API includes a check if an element has or inherits
+`pointer-events: none`.  
+This check is known to be expensive and very expensive when checking deeply
+nested nodes.
+
+This option determines how often the pointer related APIs perform the check.
+
+This is a binary flag option. You can combine multiple Levels.
+
+- `PointerEventsCheckLevel.Never`:  
+   No pointer events check
+- `PointerEventsCheckLevel.EachTarget`:  
+   Check each event target once
+- `PointerEventsCheckLevel.EachApiCall`:  
+   Check each event target once
+- `PointerEventsCheckLevel.EachTrigger`:  
+   Check pointer events on every user interaction that triggers a bunch of events.
+  E.g. once for releasing a mouse button even though this triggers `pointerup`, `mouseup`,
+  `click`, etc...
+
+`default`: `PointerEventsCheckLevel.EachApiCall`
+
+### pointerMap
+
+An array of available pointer keys.
+
+This allows to plug in different pointer devices.
+
+`default`:
+[A simple mouse and a touchscreen](https://github.com/testing-library/user-event/blob/beta/src/pointer/keyMap.ts)
+
+### skipAutoClose
+
+[`type()`](utility#type) automatically releases any keys still pressed at the
+end of the call.  
+This option allows to opt out of this feature.
+
+`default`: false
+
+### skipClick
+
+[`type()`](utility#type) implies a click on the element.  
+This option allows to opt out of this feature.
+
+`default`: false
+
+### skipHover
+
+[`click()`](utility#click) implies moving the cursor to the target element
+first.  
+This options allows to opt out of this feature.
+
+### writeToClipboard
+
+Write selected data to
+[Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) when
+a `cut` or `copy` is triggered. The Clipboard API is usually not available to
+test code. Our [`setup()`](setup) replaces the `navigator.clipboard` property
+with a stub.
+
+`default` when calling the APIs [directly](setup#direct-api): `false`  
+`default` when calling the APIs on an instance from `setup()`: `true`

--- a/docs/user-event/setup.mdx
+++ b/docs/user-event/setup.mdx
@@ -1,0 +1,50 @@
+---
+id: setup
+title: Setup
+---
+
+When users interact in the browser by e.g. pressing keyboard keys, they interact
+with a UI layer the browser shows to them. The browser then interprets this
+input, possibly alters the underlying DOM accordingly and dispatches
+[trusted](https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted)
+events.  
+The UI layer and trusted events are not programmatically available.  
+Therefore `user-event` has to apply workarounds and mock the UI layer to
+simulate user interactions like they would happen in the browser.
+
+## Starting a session per `setup()`
+
+```ts
+setup(options?: Options): UserEvent
+```
+
+The `userEvent.setup()` API applies these workarounds to the document and allows
+you to [configure](options) an "instance" of `user-event`.  
+Methods on this instance share one input device state, e.g. which keys are
+pressed.
+
+This allows to write multiple consecutive interactions that behave just like the
+described interactions by a real user.
+
+```js
+const user = userEvent.setup()
+
+await user.keyboard('[ShiftLeft>]') // Press Shift (without releasing it)
+await user.click(element) // Perform a click with `shiftKey: true`
+```
+
+The instance exposes another `.setup()` API that allows to configure another
+instance that shares the same input device state.
+
+The [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard)
+is usually not available outside of secure context.  
+To enable testing of workflows involving the clipboard,
+[`userEvent.setup()`](setup) replaces `window.navigator.clipboard` with a stub.
+
+## Direct APIs
+
+You can also call the APIs directly on the default export. This will call
+`setup` internally and then use the method on the instance.
+
+This exists to ease the transition to version 14 and writing simple tests. Using
+the methods on the instances returned by `userEvent.setup()` is recommended.

--- a/sidebars.js
+++ b/sidebars.js
@@ -172,6 +172,19 @@ module.exports = {
     {
       Ecosystem: [
         'ecosystem-user-event',
+        {
+          'user-event v14': [
+            'user-event/intro',
+            'user-event/install',
+            'user-event/setup',
+            'user-event/options',
+            'user-event/pointer',
+            'user-event/keyboard',
+            'user-event/clipboard',
+            'user-event/utility',
+            'user-event/convenience',
+          ],
+        },
         'ecosystem-jest-dom',
         'ecosystem-bs-jest-dom',
         'ecosystem-jest-native',

--- a/sidebars.js
+++ b/sidebars.js
@@ -170,21 +170,24 @@ module.exports = {
       ],
     },
     {
-      Ecosystem: [
+      type: 'category',
+      label: 'User Interactions',
+      collapsed: true,
+      items: [
+        'user-event/intro',
+        'user-event/install',
+        'user-event/setup',
+        'user-event/options',
+        'user-event/pointer',
+        'user-event/keyboard',
+        'user-event/clipboard',
+        'user-event/utility',
+        'user-event/convenience',
         'ecosystem-user-event',
-        {
-          'user-event v14': [
-            'user-event/intro',
-            'user-event/install',
-            'user-event/setup',
-            'user-event/options',
-            'user-event/pointer',
-            'user-event/keyboard',
-            'user-event/clipboard',
-            'user-event/utility',
-            'user-event/convenience',
-          ],
-        },
+      ],
+    },
+    {
+      Ecosystem: [
         'ecosystem-jest-dom',
         'ecosystem-bs-jest-dom',
         'ecosystem-jest-native',


### PR DESCRIPTION
Add documentation for `user-event@14` alongside `v13` for rest of `beta`.

New projects / projects that someone is actively working on should probably already switch to `v14-0.0-beta`, but I want to wait for more feedback before declaring this `stable`.
I hope the new documentation helps with this.
