### PR TITLE
Update Router props based on react-router-dom v6

### DIFF
--- a/docs/example-react-router.mdx
+++ b/docs/example-react-router.mdx
@@ -159,7 +159,7 @@ test('rendering a component that uses useLocation', () => {
 })
 ```
 
-## React Router v5 and Testing Library
+## Testing Library and React Router v5 
 
 In React Router v5, you need to pass the history object as a whole to the Route component.
 

--- a/docs/example-react-router.mdx
+++ b/docs/example-react-router.mdx
@@ -3,6 +3,8 @@ id: example-react-router
 title: React Router
 ---
 
+The example below now supports React Router v6.
+
 ```jsx
 // app.js
 import React from 'react'
@@ -156,3 +158,17 @@ test('rendering a component that uses useLocation', () => {
   expect(screen.getByTestId('location-display')).toHaveTextContent(route)
 })
 ```
+
+## React Router v5 and Testing Library
+
+In React Router v5, you need to pass the history object as a whole to the Route component.
+
+```jsx
+test('full app rendering/navigating', () => {
+  const history = createMemoryHistory()
+  render(
+    <Router history={history} />
+      <App />
+    </Router>,
+  )
+  ```

--- a/docs/example-react-router.mdx
+++ b/docs/example-react-router.mdx
@@ -58,7 +58,7 @@ import {App, LocationDisplay} from './app'
 test('full app rendering/navigating', () => {
   const history = createMemoryHistory()
   render(
-    <Router history={history}>
+    <Router location={history.location} navigator={history}>
       <App />
     </Router>,
   )
@@ -77,7 +77,7 @@ test('landing on a bad page', () => {
   const history = createMemoryHistory()
   history.push('/some/bad/route')
   render(
-    <Router history={history}>
+    <Router location={history.location} navigator={history}>
       <App />
     </Router>,
   )
@@ -90,7 +90,7 @@ test('rendering a component that uses useLocation', () => {
   const route = '/some-route'
   history.push(route)
   render(
-    <Router history={history}>
+    <Router location={history.location} navigator={history}>
       <LocationDisplay />
     </Router>,
   )


### PR DESCRIPTION
Since react-router-dom v6, there's no history object on Router anymore. Instead, the objects navigator and location needs to be used. Reference:
https://stackoverflow.com/questions/69859509/cannot-read-properties-of-undefined-reading-pathname-when-testing-pages-in