### PR TITLE
feat: add top-level redirect for `user-event`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -103,3 +103,6 @@
 [[redirects]]
   from = "/nightwatch/"
   to = "/docs/nightwatch-testing-library/intro"
+[[redirects]]
+  from = "/user-event/"
+  to = "/docs/user-event/intro"


### PR DESCRIPTION
Add a top-level redirect for sharing an URL that is a) shorter and b) independent from possible future reorganizing of docs pages.