### PR TITLE
Add vue3 quickstart instruction

### DIFF
--- a/docs/vue-testing-library/intro.mdx
+++ b/docs/vue-testing-library/intro.mdx
@@ -20,8 +20,13 @@ In short, Vue Testing Library does three things:
 
 ## Quickstart
 
+If using Vue2
 ```
 npm install --save-dev @testing-library/vue
+```
+If using Vue3
+```
+npm install --save-dev @testing-library/vue@next
 ```
 
 You can now use all of `DOM Testing Library`'s `getBy`, `getAllBy`, `queryBy`


### PR DESCRIPTION
If you don't install using @next and you are using Vue3 you get an error regarding vue-template-compiler not being found.