### PR TITLE
docs(user-event): fix code example of `clear` API

### DIFF
--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -368,10 +368,10 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 test('clear', () => {
-  render(<textarea value="Hello, World!" />)
+  render(<textarea defaultValue="Hello, World!" />)
 
   userEvent.clear(screen.getByRole('textbox'))
-  expect(screen.getByRole('textbox')).toHaveAttribute('value', '')
+  expect(screen.getByRole('textbox')).toHaveValue('')
 })
 ```
 


### PR DESCRIPTION
Fix code example of [`clear`](https://testing-library.com/docs/ecosystem-user-event#clearelement) API in **user-events v13** docs.

The current code example does not work and causes confusion because React value prop without an onChange handler causes the field to be read-only. Also `value` attribute is `null`.

So I changed two things:
- `value` to `defaultValue` prop 
-  `toHaveAttribute('value', '')` to `toHaveValue('')`

The example code for `clear` in [Utility APIs ](https://testing-library.com/docs/user-event/utility#clear) is also following this method.