### PR TITLE
fix(queries): use role `img` instead of `image`

### DIFF
--- a/docs/queries/byrole.mdx
+++ b/docs/queries/byrole.mdx
@@ -62,7 +62,7 @@ accessible name query does not replace other queries such as `*ByAlt` or
 `*ByTitle`. While the accessible name can be equal to these attributes, it does
 not replace the functionality of these attributes. For example
 `<img aria-label="fancy image" src="fancy.jpg" />` will be returned for both
-`getByAltText('fancy image')` and `getByRole('image', { name: 'fancy image' })`.
+`getByAltText('fancy image')` and `getByRole('img', { name: 'fancy image' })`.
 However, the image will not display its description if `fancy.jpg` could not be
 loaded. Whether you want to assert this functionality in your test or not is up
 to you.


### PR DESCRIPTION
Use `img` instead of `image` since `image` is not a valid aria-role. 

> For example `<img aria-label="fancy image" src="fancy.jpg" />` will be returned for both `getByAltText('fancy image') and getByRole('image', { name: 'fancy image' })`.
