### PR TITLE
fix(userEvent): setup borken link

### DIFF
--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -36,7 +36,7 @@ to test interaction with your components.
 
 ## Writing tests with `userEvent`
 
-We recommend to use [`userEvent.setup()`](setup) when rendering your component
+We recommend to use [`userEvent.setup()`](setup.mdx) when rendering your component
 and inline that rendering and setup in your test or use a setup function.  
 We discourage rendering or using any `userEvent` functions outside of the test
 itself - e.g. in a `before`/`after` hook - for reasons described in


### PR DESCRIPTION
It fixes the link in Github. ~I'm not sure if it's gonna fix the [link on the website](https://testing-library.com/docs/user-event/intro/#:~:text=recommend%20to%20use-,userEvent.setup(),-when%20rendering%20your)~

https://deploy-preview-996--testing-library.netlify.app/docs/user-event/setup