### PR TITLE
append every link with .mdx for a better navigation

### DIFF
--- a/docs/user-event/api-clipboard.mdx
+++ b/docs/user-event/api-clipboard.mdx
@@ -7,7 +7,7 @@ Note that the
 [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) is
 usually not available outside of secure context.  
 To enable testing of workflows involving the clipboard,
-[`userEvent.setup()`](setup) replaces `window.navigator.clipboard` with a stub.
+[`userEvent.setup()`](setup.mdx) replaces `window.navigator.clipboard` with a stub.
 
 ## copy()
 
@@ -17,7 +17,7 @@ copy(): Promise<DataTransfer|undefined>
 
 Copy the current selection.
 
-If [`writeToClipboard`](options#writetoclipboard) is `true`, this will also
+If [`writeToClipboard`](options.mdx#writetoclipboard) is `true`, this will also
 write the data to the `Clipboard`.
 
 ## cut()
@@ -28,7 +28,7 @@ cut(): Promise<DataTransfer|undefined>
 
 Cut the current selection.
 
-If [`writeToClipboard`](options#writetoclipboard) is `true`, this will also
+If [`writeToClipboard`](options.mdx#writetoclipboard) is `true`, this will also
 write the data to the `Clipboard`.
 
 When performed in editable context, it removes the selected content from the

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -4,7 +4,7 @@ title: Convenience APIs
 ---
 
 The following APIs are shortcuts for equivalent calls to the underlying
-[`pointer()`](pointer) and [`keyboard()`](keyboard) APIs.
+[`pointer()`](api-pointer.mdx) and [`keyboard()`](api-keyboard.mdx) APIs.
 
 ## Clicks
 
@@ -18,7 +18,7 @@ click(element: Element): Promise<void>
 pointer([{target: element}, {keys: '[MouseLeft]', target: element}])
 ```
 
-The first action might be skipped per [`skipHover`](options#skiphover).
+The first action might be skipped per [`skipHover`](options.mdx#skiphover).
 
 ### dblClick()
 

--- a/docs/user-event/api-keyboard.mdx
+++ b/docs/user-event/api-keyboard.mdx
@@ -71,7 +71,7 @@ keyboard('{Shift>}A{/Shift}') // translates to: Shift(down), A, Shift(up)
 The mapping of `key` to `code` is performed by a
 [default key map](https://github.com/testing-library/user-event/blob/beta/src/keyboard/keyMap.ts)
 portraying a "default" US-keyboard. You can provide your own local keyboard
-mapping per [`keyboardMap`](options#keyboardmap) option.
+mapping per [`keyboardMap`](options.mdx#keyboardmap) option.
 
 Currently the different `key` meanings of single keys are treated as different
 keys.
@@ -79,5 +79,5 @@ keys.
 > Future versions might try to interpolate the modifiers needed to reach a
 > printable key on the keyboard. E.g. Automatically pressing `{Shift}` when
 > CapsLock is not active and `A` is referenced. If you don't wish this behavior,
-> you can deactivate the [`autoModify`](options#automodify) option to opt out
+> you can deactivate the [`autoModify`](options.mdx#automodify) option to opt out
 > of this non-breaking change.

--- a/docs/user-event/api-pointer.mdx
+++ b/docs/user-event/api-pointer.mdx
@@ -52,7 +52,7 @@ pointer('[MouseLeft>]') // press the left mouse button
 pointer('[/MouseLeft]') // release the left mouse button
 ```
 
-Which buttons are available depends on the [`pointerMap`](options#pointermap).
+Which buttons are available depends on the [`pointerMap`](options.mdx#pointermap).
 
 ### <a name="move" href="#"/>Moving a pointer
 

--- a/docs/user-event/api-utility.mdx
+++ b/docs/user-event/api-utility.mdx
@@ -96,7 +96,7 @@ test('deselectOptions', async () => {
 ```
 
 Note that this API triggers pointer events and is therefore subject to
-[pointerEventsCheck](options#pointereventscheck).
+[pointerEventsCheck](options.mdx#pointereventscheck).
 
 ## type()
 
@@ -115,16 +115,16 @@ type(
 
 Type into an input element.
 
-> You should use [`keyboard()`](keyboard) if you want to just simulate pressing
+> You should use [`keyboard()`](api-keyboard.mdx) if you want to just simulate pressing
 > buttons on the keyboard.  
 > You can use `type()` if you just want to conveniently insert some text into an
 > input field or textarea.
 
-1. Unless [`skipClick`](options#skipclick) is `true`, click the element.
+1. Unless [`skipClick`](options.mdx#skipclick) is `true`, click the element.
 1. If `initialSelectionStart` is set, set the selection on the element. If
    `initialSelectionEnd` is not set, this results in a collapsed selection.
-1. Type the given `text` per [`keyboard()`](keyboard).
-1. Unless [`skipAutoClose`](options#skipautoclose) is `true`, release all
+1. Type the given `text` per [`keyboard()`](api-keyboard.mdx).
+1. Unless [`skipAutoClose`](options.mdx#skipautoclose) is `true`, release all
    pressed keys.
 
 ```jsx

--- a/docs/user-event/install.mdx
+++ b/docs/user-event/install.mdx
@@ -29,7 +29,7 @@ yarn add --dev @testing-library/user-event@^14.0.0-beta
 Note that `@testing-library/user-event` requires `@testing-library/dom`.
 
 If you use one of the
-[framework wrappers](../dom-testing-library/install#wrappers), it is important
+[framework wrappers](../dom-testing-library/install.mdx#wrappers), it is important
 that `@testing-library/dom` is resolved to the same installation required by the
 framework wrapper of your choice.  
 Usually this means that if you use one of the framework wrappers, you should not

--- a/docs/user-event/options.mdx
+++ b/docs/user-event/options.mdx
@@ -4,11 +4,11 @@ title: Options
 ---
 
 The following options allow to adjust the behavior of `user-event` APIs.
-They can be applied per [`setup()`](setup).
+They can be applied per [`setup()`](setup.mdx).
 
 ### applyAccept
 
-When using [`upload()`](utility#upload), automatically discard files that don't
+When using [`upload()`](api-utility.mdx#upload), automatically discard files that don't
 match an `accept` property if such property exists on the element.
 
 `default`: `true`
@@ -41,7 +41,7 @@ This moves the next changes at least to the next macro task and allows other
 The document.
 
 This defaults to the owner document of an element if an API is called
-[directly](setup#direct-api) with an element and without setup. Otherwise it
+[directly](setup.mdx#direct-api) with an element and without setup. Otherwise it
 falls back to the global document.
 
 `default`: `element.ownerDocument ?? global.document`
@@ -90,7 +90,7 @@ This allows to plug in different pointer devices.
 
 ### skipAutoClose
 
-[`type()`](utility#type) automatically releases any keys still pressed at the
+[`type()`](api-utility.mdx#type) automatically releases any keys still pressed at the
 end of the call.  
 This option allows to opt out of this feature.
 
@@ -98,14 +98,14 @@ This option allows to opt out of this feature.
 
 ### skipClick
 
-[`type()`](utility#type) implies a click on the element.  
+[`type()`](api-utility.mdx#type) implies a click on the element.  
 This option allows to opt out of this feature.
 
 `default`: false
 
 ### skipHover
 
-[`click()`](utility#click) implies moving the cursor to the target element
+[`click()`](api-utility.mdx#click) implies moving the cursor to the target element
 first.  
 This options allows to opt out of this feature.
 
@@ -114,8 +114,8 @@ This options allows to opt out of this feature.
 Write selected data to
 [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) when
 a `cut` or `copy` is triggered. The Clipboard API is usually not available to
-test code. Our [`setup()`](setup) replaces the `navigator.clipboard` property
+test code. Our [`setup()`](setup.mdx) replaces the `navigator.clipboard` property
 with a stub.
 
-`default` when calling the APIs [directly](setup#direct-api): `false`  
+`default` when calling the APIs [directly](setup.mdx#direct-api): `false`  
 `default` when calling the APIs on an instance from `setup()`: `true`

--- a/docs/user-event/setup.mdx
+++ b/docs/user-event/setup.mdx
@@ -19,7 +19,7 @@ setup(options?: Options): UserEvent
 ```
 
 The `userEvent.setup()` API applies these workarounds to the document and allows
-you to [configure](options) an "instance" of `user-event`.  
+you to [configure](options.mdx) an "instance" of `user-event`.  
 Methods on this instance share one input device state, e.g. which keys are
 pressed.
 
@@ -39,7 +39,7 @@ instance that shares the same input device state.
 The [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard)
 is usually not available outside of secure context.  
 To enable testing of workflows involving the clipboard,
-[`userEvent.setup()`](setup) replaces `window.navigator.clipboard` with a stub.
+[`userEvent.setup()`](setup.mdx) replaces `window.navigator.clipboard` with a stub.
 
 ## Direct APIs
 


### PR DESCRIPTION
This PR appends `.mdx` to all internal links of user-event.
This should cover the last cases that can give a 404 page.