### PR TITLE
docs: update the rerender method using the unmount method before

### DIFF
--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -207,10 +207,15 @@ to ensure that the props are being updated correctly (see
 prefer to update the props of a rendered component in your test, this function
 can be used to update props of the rendered component.
 
+To use rerender it is necessary to use the unmount method to undo the previous rendering context.
+
 ```jsx
 import {render} from '@testing-library/react'
 
-const {rerender} = render(<NumberDisplay number={1} />)
+const {rerender, unmount} = render(<NumberDisplay number={1} />)
+
+// this will cause the rendered component to be unmounted
+unmount()
 
 // re-render the same component with different props
 rerender(<NumberDisplay number={2} />)


### PR DESCRIPTION
The rerender method is a method that needs to be unmounted, otherwise it will take the previous rendering context, thus failing the test.
I recently ran into this problem and didn't find it in the "rerender" method section in the documentation.