### PR TITLE
docs: fix fireEvent Example code

### DIFF
--- a/docs/preact-testing-library/api.mdx
+++ b/docs/preact-testing-library/api.mdx
@@ -113,12 +113,13 @@ fireEvent.click(buttonNode);
 
 // Fire event Option 2.
 fireEvent(
-buttonNode,
-new Event('MouseEvent', {
-  bubbles: true,
-  cancelable: true,
-  button: 0,
-});
+  buttonNode,
+  new Event('MouseEvent', {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+  })
+);
 
 expect(buttonNode).toHaveTextContent('1');
 expect(cb).toHaveBeenCalledTimes(1);

--- a/docs/preact-testing-library/api.mdx
+++ b/docs/preact-testing-library/api.mdx
@@ -117,7 +117,6 @@ fireEvent(
   new Event('MouseEvent', {
     bubbles: true,
     cancelable: true,
-    button: 0,
   })
 );
 

--- a/docs/preact-testing-library/api.mdx
+++ b/docs/preact-testing-library/api.mdx
@@ -114,9 +114,10 @@ fireEvent.click(buttonNode);
 // Fire event Option 2.
 fireEvent(
   buttonNode,
-  new Event('MouseEvent', {
+  new MouseEvent('click', {
     bubbles: true,
     cancelable: true,
+    button: 0,
   })
 );
 


### PR DESCRIPTION
When I copied the code example, there was an error, so I fixed it.
https://testing-library.com/docs/preact-testing-library/api/#example-1

- Fix syntax error
- Delete undefined prop
  - https://developer.mozilla.org/en-US/docs/Web/API/Event/Event
