### PR TITLE
Clarify compatible versions for Vue 2 and Vue 3

### DIFF
--- a/docs/vue-testing-library/intro.mdx
+++ b/docs/vue-testing-library/intro.mdx
@@ -22,11 +22,11 @@ In short, Vue Testing Library does three things:
 
 If using Vue2
 ```
-npm install --save-dev @testing-library/vue
+npm install --save-dev @testing-library/vue@5
 ```
 If using Vue3
 ```
-npm install --save-dev @testing-library/vue@next
+npm install --save-dev @testing-library/vue
 ```
 
 You can now use all of `DOM Testing Library`'s `getBy`, `getAllBy`, `queryBy`


### PR DESCRIPTION
The `latest` tag of `@testing-library/vue` points to a version that is incompatible with Vue 2. This is not reflected in the documentation so I added the correct versions to the example command.