### PR TITLE
docs: keyPress warning

### DIFF
--- a/docs/dom-testing-library/api-events.mdx
+++ b/docs/dom-testing-library/api-events.mdx
@@ -96,6 +96,9 @@ fireEvent.keyDown(domNode, {key: 'Enter', code: 'Enter', charCode: 13})
 fireEvent.keyDown(domNode, {key: 'A', code: 'KeyA'})
 ```
 
+> :warning: Be careful to provide the `charCode` property in case of firing the
+> `keyPress` event. Otherwise, it won't be fired.
+
 You can find out which key code to use at
 [https://keycode.info/](https://keycode.info/).
 

--- a/docs/dom-testing-library/api-events.mdx
+++ b/docs/dom-testing-library/api-events.mdx
@@ -96,9 +96,8 @@ fireEvent.keyDown(domNode, {key: 'Enter', code: 'Enter', charCode: 13})
 fireEvent.keyDown(domNode, {key: 'A', code: 'KeyA'})
 ```
 
-> :warning: Be careful to provide the `charCode` property in case of firing the
-> `keyPress` event. Otherwise, it won't be fired.
-
+> :warning: `React` doesn't dispatch a `SyntheticEvent` for a native `keypress` event without `event.charCode === 13 || event.charCode >= 32`.
+> I.e. `onKeyPress` handlers will only be called if you include an appropriate `charCode` property.
 You can find out which key code to use at
 [https://keycode.info/](https://keycode.info/).
 


### PR DESCRIPTION
To stress out the aspect of not firing the `keyPress` event not having specified the charCode property.
https://github.com/testing-library/react-testing-library/issues/269#issuecomment-455854112 