### PR TITLE
Update queries/about.mdx

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -143,7 +143,8 @@ want to query `document.body` then you can use the [`screen`](#screen) export as
 demonstrated below (using `screen` is recommended).
 
 The primary argument to a query can be a _string_, _regular expression_, or
-_function_. There are also options to adjust how node text is parsed. See
+_function_. If you pass a function, it will receive `content` and `element` as parameters.
+There are also options to adjust how node text is parsed. See
 [TextMatch](#textmatch) for documentation on what can be passed to a query.
 
 Given the following DOM elements (which can be rendered by React, Vue, Angular,
@@ -169,6 +170,13 @@ const inputNode1 = screen.getByLabelText('Username')
 // Without screen, you need to provide a container:
 const container = document.querySelector('#app')
 const inputNode2 = getByLabelText(container, 'Username')
+```
+### `queryOptions`
+
+There are several options that you can pass to queries, though in most cases you won't need any. 
+
+```js
+screen.getByRole('list', { hidden: true })
 ```
 
 ### `screen`
@@ -238,7 +246,7 @@ cy.findByLabelText('Example').should('exist')
 
 Most of the query APIs take a `TextMatch` as an argument, which means the
 argument can be either a _string_, _regex_, or a _function_ which returns `true`
-for a match and `false` for a mismatch.
+for a match and `false` for a mismatch. If you pass a function, it will receive `content` and `element` as parameters.
 
 ### TextMatch Examples
 

--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -143,8 +143,7 @@ want to query `document.body` then you can use the [`screen`](#screen) export as
 demonstrated below (using `screen` is recommended).
 
 The primary argument to a query can be a _string_, _regular expression_, or
-_function_. If you pass a function, it will receive `content` and `element` as parameters.
-There are also options to adjust how node text is parsed. See
+_function_. There are also options to adjust how node text is parsed. See
 [TextMatch](#textmatch) for documentation on what can be passed to a query.
 
 Given the following DOM elements (which can be rendered by React, Vue, Angular,
@@ -173,11 +172,13 @@ const inputNode2 = getByLabelText(container, 'Username')
 ```
 ### `queryOptions`
 
-There are several options that you can pass to queries, though in most cases you won't need any. 
+You can pass a `queryOptions` object with the query type, e.g.:
 
 ```js
-screen.getByRole('list', { hidden: true })
+screen.getByRole('list', { hidden: true });
 ```
+
+Note that the available query options are different for each query type.
 
 ### `screen`
 
@@ -245,8 +246,8 @@ cy.findByLabelText('Example').should('exist')
 ## `TextMatch`
 
 Most of the query APIs take a `TextMatch` as an argument, which means the
-argument can be either a _string_, _regex_, or a _function_ which returns `true`
-for a match and `false` for a mismatch. If you pass a function, it will receive `content` and `element` as parameters.
+argument can be either a _string_, _regex_, or a _function_ of signature `(content?: string, element?: Element | null) => boolean` which returns `true`
+for a match and `false` for a mismatch.
 
 ### TextMatch Examples
 

--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -172,7 +172,7 @@ const inputNode2 = getByLabelText(container, 'Username')
 ```
 ### `queryOptions`
 
-You can pass a `queryOptions` object with the query type. See the docs for each query type to see available options, e.g. [here](https://testing-library.com/docs/queries/byrole#api).
+You can pass a `queryOptions` object with the query type. See the docs for each query type to see available options, e.g. [byRole API](queries/byrole.mdx#api).
 
 ### `screen`
 

--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -172,13 +172,7 @@ const inputNode2 = getByLabelText(container, 'Username')
 ```
 ### `queryOptions`
 
-You can pass a `queryOptions` object with the query type, e.g.:
-
-```js
-screen.getByRole('list', { hidden: true });
-```
-
-Note that the available query options are different for each query type.
+You can pass a `queryOptions` object with the query type. See the docs for each query type to see available options, e.g. [here](https://testing-library.com/docs/queries/byrole#api).
 
 ### `screen`
 


### PR DESCRIPTION
`queryOptions` are mentioned, but it's never explained where you actually pass them in. Once you know it's obvious, but it wasn't initially to me ("do I pass it into the render function, to modify behavior for all queries?"), and readers shouldn't have to test until they find it.

It would be great to link to a list of the available options in `queryOptions` in the section I added, but I couldn't find such a list.

I also added a note aboout the parameters that functions passed to queries will receive. It can be derived from examples later in the document, but you have to look for them, and I think it's clearer to make it explicit when the option to pass functions is mentioned.