### PR TITLE
chore: Update netlify config for `format-docs` to `format` script change

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
   publish = "build"
 
   # Default build command
-  command = "npm install; npm run format-docs; npm run build"
+  command = "npm install; npm run format; npm run build"
 
 [dev]
   # A Boolean value that determines if Netlify Dev launches the local server address in your browser


### PR DESCRIPTION
Noticed consistent errors in the Netlify build log about a missing `format-docs` script. Looks like this happened back with #957.

Here is a recent build log: https://app.netlify.com/sites/testing-library/deploys/627228a19893d40008ebd381