### PR TITLE
Just add an alternative location for the React Testing Examples

### DIFF
--- a/docs/example-external.mdx
+++ b/docs/example-external.mdx
@@ -6,10 +6,7 @@ sidebar_label: External Examples
 
 ## Code Samples
 
-- You can find more React Testing Library examples at
-  [react-testing-examples.com](https://react-testing-examples.com/jest-rtl/).
-  
-  If the link does not work, try the netlify one: [react-testing-examples.netlify.app](https://react-testing-examples.netlify.app/).
+- You can find more React Testing Library examples at [https://react-testing-examples.netlify.app/](https://react-testing-examples.netlify.app/).
 
 ## Playground
 

--- a/docs/example-external.mdx
+++ b/docs/example-external.mdx
@@ -8,6 +8,8 @@ sidebar_label: External Examples
 
 - You can find more React Testing Library examples at
   [react-testing-examples.com](https://react-testing-examples.com/jest-rtl/).
+  
+  If the link does not work, try the netlify one: [react-testing-examples.netlify.app](https://react-testing-examples.netlify.app/).
 
 ## Playground
 


### PR DESCRIPTION
I am in no way affiliated with the project, I just wanted to add a link that was not dead.