### PR TITLE
Updated jest v27 instructions to v28

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -285,17 +285,36 @@ using Create React App without TypeScript, save this to `jsconfig.json` instead.
 
 ### Jest 28
 
-If you're using a recent version of Jest (28 or later), jest-environment-jsdom package now must be installed separately. 
+If you're using Jest 28 or later, jest-environment-jsdom package now must be installed separately. 
 ```
 npm install --save-dev jest-environment-jsdom
 ```
     
-`jsdom` is also no longer the default environment. You can enable `jsdom` globally by editing
-`jest.config.js`:
+`jsdom` is also no longer the default environment. You can enable `jsdom` globally by editing `jest.config.js`:
 
 ```diff title="jest.config.js"
  module.exports = {
 +  testEnvironment: 'jsdom',
+   // ... other options ...
+ }
+```
+
+Or if you only need `jsdom` in some of your tests, you can enable it as and when needed using
+[docblocks](https://jestjs.io/docs/configuration#testenvironment-string):
+
+```js
+/**
+ * @jest-environment jsdom
+ */
+```
+
+### Jest 27
+
+If you're using a recent version of Jest (27), `jsdom` is no longer the default environment. You can enable `jsdom` globally by editing `jest.config.js`:
+
+```diff title="jest.config.js"
+ module.exports = {
++  testEnvironment: 'jest-environment-jsdom',
    // ... other options ...
  }
 ```

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -283,15 +283,19 @@ using Create React App without TypeScript, save this to `jsconfig.json` instead.
 }
 ```
 
-### Jest 27
+### Jest 28
 
-If you're using a recent version of Jest (27 or later), `jsdom` is no longer the
-default environment. You can enable `jsdom` globally by editing
+If you're using a recent version of Jest (28 or later), jest-environment-jsdom package now must be installed separately. 
+```
+npm install --save-dev jest-environment-jsdom
+```
+    
+`jsdom` is also no longer the default environment. You can enable `jsdom` globally by editing
 `jest.config.js`:
 
 ```diff title="jest.config.js"
  module.exports = {
-+  testEnvironment: 'jest-environment-jsdom',
++  testEnvironment: 'jsdom',
    // ... other options ...
  }
 ```


### PR DESCRIPTION

Added instruction on jsdom setup as it now isn't shipped with jest as of v28.

https://jestjs.io/docs/upgrading-to-jest28#jsdom
"If you are using JSDOM test environment, jest-environment-jsdom package now must be installed separately"