### PR TITLE
docs(jest-dom): fix import typo

### DIFF
--- a/docs/ecosystem-jest-dom.mdx
+++ b/docs/ecosystem-jest-dom.mdx
@@ -14,7 +14,7 @@ Then follow [usage section][gh-usage] from jest-dom's documentation to add the
 matchers to Jest.
 
 ```jsx
-import {screen} from '@testing-library/dom'
+import {screen} from '@testing-library/jest-dom'
 
 test('uses jest-dom', () => {
   document.body.innerHTML = `


### PR DESCRIPTION
Small a fix typo in the `import` part of the code example.