### PR TITLE
docs: add missing `useState` import to React Transition Group example

### DIFF
--- a/docs/example-react-transition-group.mdx
+++ b/docs/example-react-transition-group.mdx
@@ -54,7 +54,7 @@ test('you can mock things with jest.mock', () => {
 ## Shallow
 
 ```jsx
-import React from 'react'
+import React, {useState} from 'react'
 import {CSSTransition} from 'react-transition-group'
 import {render, fireEvent} from '@testing-library/react'
 


### PR DESCRIPTION
From https://github.com/testing-library/testing-library-docs/pull/1066#discussion_r877935074

Adding missing `useState` import to React Transition Group example.