### PR TITLE
Fix tags for correct vue2/vue3 support

### DIFF
--- a/docs/vue-testing-library/intro.mdx
+++ b/docs/vue-testing-library/intro.mdx
@@ -22,11 +22,11 @@ In short, Vue Testing Library does three things:
 
 If using Vue2
 ```
-npm install --save-dev @testing-library/vue@5
+npm install --save-dev @testing-library/vue
 ```
 If using Vue3
 ```
-npm install --save-dev @testing-library/vue
+npm install --save-dev @testing-library/vue@next
 ```
 
 You can now use all of `DOM Testing Library`'s `getBy`, `getAllBy`, `queryBy`


### PR DESCRIPTION
Currently the `latest` tag points to version 5 and the `next` tag points to version 6.
This would revert [commit ac0737e57af1](https://github.com/testing-library/testing-library-docs/commit/ac0737e57af1b3b86cea039beef631e7e52b67f7).