### PR TITLE
docs: add a note on when not to use renderHook

### DIFF
--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -328,7 +328,10 @@ react supports `act`. It is recommended to use the import from
 
 This is a convenience wrapper around `render` with a custom test component. The
 API emerged from a popular testing pattern and is mostly interesting for
-libraries publishing hooks. You should prefer `render` since a custom test
+libraries publishing hooks. 
+
+Do not use `renderHook` when your hook is easy to test by just testing the components using it.
+Alternatively, you should prefer `render` since a custom test
 component results in more readable and robust tests since the thing you want to
 test is not hidden behind an abstraction.
 


### PR DESCRIPTION
In https://github.com/testing-library/react-hooks-testing-library/blob/main/README.md there are two reasons when not to use react-hooks-testing-library:

> 1. Your hook is defined alongside a component and is only used there 2. Your hook is easy to test by just testing the components using it

I think it still holds true and it would make sense to add this into `renderHook` docs. I've omitted the first point because it seems like the second point covers it. We could add both, though.