### PR TITLE
Remove mention to Firefox extension in about.mdx

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -408,7 +408,6 @@ Do you still have problems knowing how to use Testing Library queries?
 
 There is a very cool Browser extension for
 [Chrome](https://chrome.google.com/webstore/detail/testing-playground/hejbmebodbijjdhflfknehhcgaklhano/related)
-and [Firefox](https://addons.mozilla.org/en/firefox/addon/testing-playground/)
 named Testing Playground, and it helps you find the best queries to select
 elements. It allows you to inspect the element hierarchies in the Browser's
 Developer Tools, and provides you with suggestions on how to select them, while


### PR DESCRIPTION
Linked firefox extension was removed from the store; update the text to remove its mention