### PR TITLE
Clarifying user-event's capabilities vs fire-event

### DIFF
--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -47,6 +47,9 @@ to test interaction with your components.
 There are, however, some user interactions or aspects of these [that aren't yet implemented and thus can't yet be described with `user-event`](https://github.com/testing-library/user-event/issues?q=is%3Aopen+label%3Aaccuracy%2Cenhancement).
 In these cases you can use `fireEvent` to dispatch the concrete events that your software relies on.
 
+Note that this makes your component and/or test reliant upon your assumptions about the concrete aspects of the interaction being correct.
+Therefore if you already put in the work to specify the correct aspects of such interaction, please consider contributing to this project so that user-event might cover these cases too.
+
 ## Writing tests with `userEvent`
 
 We recommend invoking [`userEvent.setup()`](setup.mdx) before the component is

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -44,7 +44,8 @@ This is
 [why you should use `user-event`](https://ph-fritsche.github.io/blog/post/why-userevent)
 to test interaction with your components. 
 
-There are, however, some user interactions that can't yet be described with `user-event` - selecting values on a slider, for example - for which `fire-event` is necessary.
+There are, however, some user interactions or aspects of these [that aren't yet implemented and thus can't yet be described with `user-event`](https://github.com/testing-library/user-event/issues?q=is%3Aopen+label%3Aaccuracy%2Cenhancement).
+In these cases you can use `fireEvent` to dispatch the concrete events that your software relies on.
 
 ## Writing tests with `userEvent`
 

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -48,7 +48,7 @@ There are, however, some user interactions or aspects of these [that aren't yet 
 In these cases you can use `fireEvent` to dispatch the concrete events that your software relies on.
 
 Note that this makes your component and/or test reliant upon your assumptions about the concrete aspects of the interaction being correct.
-Therefore if you already put in the work to specify the correct aspects of such interaction, please consider contributing to this project so that user-event might cover these cases too.
+Therefore if you already put in the work to specify the correct aspects of such interaction, please consider contributing to this project so that `user-event` might cover these cases too.
 
 ## Writing tests with `userEvent`
 

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -44,7 +44,7 @@ This is
 [why you should use `user-event`](https://ph-fritsche.github.io/blog/post/why-userevent)
 to test interaction with your components. 
 
-There are, however, some user interactions that can't yet be described with `user-event`, for which `fire-event` is necessary.
+There are, however, some user interactions that can't yet be described with `user-event` - selecting values on a slider, for example - for which `fire-event` is necessary.
 
 ## Writing tests with `userEvent`
 

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -44,7 +44,7 @@ This is
 [why you should use `user-event`](https://ph-fritsche.github.io/blog/post/why-userevent)
 to test interaction with your components. 
 
-There are some user interactions that can't yet be described with `user-event`, for which `fire-event` is necessary.
+There are, however, some user interactions that can't yet be described with `user-event`, for which `fire-event` is necessary.
 
 ## Writing tests with `userEvent`
 

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -42,7 +42,9 @@ factors in that the browser e.g. wouldn't let a user click a hidden element or
 type in a disabled text box.  
 This is
 [why you should use `user-event`](https://ph-fritsche.github.io/blog/post/why-userevent)
-to test interaction with your components.
+to test interaction with your components. 
+
+There are some user interactions that can't yet be described with `user-event`, for which `fire-event` is necessary.
 
 ## Writing tests with `userEvent`
 


### PR DESCRIPTION
The current intro makes it sounds like `user-event` can test all valid user interactions, and is a replacement for `fire-event` in all user-interaction cases. However, in our engineering dept., we've found that this is not the case. For example, to pick a specific value on a slider, we use:

```js
fireEvent.change(screen.getByRole('slider'), { target: { value: '3000' } })
```

We haven't been able to find any `user-event` equivalent to this. So unless there's something we're not aware of (and we've [posted the question to SO](https://stackoverflow.com/q/72775505/9154668) and received no responses), then noting that `user-event` can not replace `fire-event` in all cases would improve the clarity and usefulness of the `user-event` intro.