### PR TITLE
doc: change use of container.firstChild to asFragment

### DIFF
--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -58,9 +58,9 @@ import {render} from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 test('renders a message', () => {
-  const {container, getByText} = render(<Greeting />)
+  const {asFragment, getByText} = render(<Greeting />)
   expect(getByText('Hello, world!')).toBeInTheDocument()
-  expect(container.firstChild).toMatchInlineSnapshot(`
+  expect(asFragment()).toMatchInlineSnapshot(`
     <h1>Hello, World!</h1>
   `)
 })


### PR DESCRIPTION
fix: https://github.com/testing-library/testing-library-docs/issues/249