### PR TITLE
docs: Update Svelte setup.mdx with Vitest configuration instructions.

### DIFF
--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -153,7 +153,7 @@ with any testing framework and runner you're comfortable with.
     npm install --save-dev @testing-library/jest-dom
     ```
 
-    6.2 import `@testing-library/jest-dom` at the start of your test files
+    5.2 import `@testing-library/jest-dom` at the start of your test files
 
     ```js
     import '@testing-library/jest-dom';

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -160,7 +160,7 @@ with any testing framework and runner you're comfortable with.
     ```
 
 6.  Create your component + test file (checkout the rest of the docs to see how)
-    and run it
+    and run the following command to run the tests.
 
     ```
     npm run test

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -147,7 +147,7 @@ with any testing framework and runner you're comfortable with.
     [jest-dom](https://github.com/testing-library/jest-dom) to add handy
     assertions to Jest
 
-    6.1 Install `jest-dom`
+    5.1 Install `jest-dom`
 
     ```
     npm install --save-dev @testing-library/jest-dom

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -143,7 +143,7 @@ with any testing framework and runner you're comfortable with.
 
     ```
 
-6.  This is optional but it is recommended, you can install
+5.  This is optional but it is recommended, you can install
     [jest-dom](https://github.com/testing-library/jest-dom) to add handy
     assertions to Jest
 
@@ -159,7 +159,7 @@ with any testing framework and runner you're comfortable with.
     import '@testing-library/jest-dom';
     ```
 
-7.  Create your component + test file (checkout the rest of the docs to see how)
+6.  Create your component + test file (checkout the rest of the docs to see how)
     and run it
 
     ```

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -100,7 +100,7 @@ with any testing framework and runner you're comfortable with.
     npm run test
     ```
 ## Vitest
-1.  Install Vitest & jsdom
+1.  Install Vitest and jsdom
 
     ```
     npm install --save-dev vitest jsdom

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -99,7 +99,72 @@ with any testing framework and runner you're comfortable with.
     ```
     npm run test
     ```
+## Vitest
+1.  Install Vitest & jsdom
 
+    ```
+    npm install --save-dev vitest jsdom
+    ```
+
+2.  Add the following to your `package.json`
+
+    ```json
+    {
+      "scripts": {
+        "test": "vitest run src",
+        "test:watch": "vitest src"
+      }
+    }
+    ```
+
+3.  You'll need to compile the Svelte components before using them in Vitest, so
+    we need to install
+    [@sveltejs/vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) & Vite
+    
+
+    ```
+    npm install --save-dev @sveltejs/vite-plugin-svelte vite
+    ```
+
+4.  Add a `vitest.config.ts` configuration file to the root of your project
+
+    ```js
+    import { defineConfig } from 'vite';
+    import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+    export default defineConfig({
+        plugins: [svelte({ hot: !process.env.VITEST })],
+        test: {
+            include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+            globals: true,
+            environment: 'jsdom'
+        }
+    });
+
+    ```
+
+6.  This is optional but it is recommended, you can install
+    [jest-dom](https://github.com/testing-library/jest-dom) to add handy
+    assertions to Jest
+
+    6.1 Install `jest-dom`
+
+    ```
+    npm install --save-dev @testing-library/jest-dom
+    ```
+
+    6.2 import `@testing-library/jest-dom` at the start of your test files
+
+    ```js
+    import '@testing-library/jest-dom';
+    ```
+
+7.  Create your component + test file (checkout the rest of the docs to see how)
+    and run it
+
+    ```
+    npm run test
+    ```
 ## Typescript
 
 To use Typescript, you'll need to install and configure `svelte-preprocess` and

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -119,7 +119,7 @@ with any testing framework and runner you're comfortable with.
 
 3.  You'll need to compile the Svelte components before using them in Vitest, so
     you need to install
-    [@sveltejs/vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) & Vite
+    [@sveltejs/vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) and Vite
     
 
     ```
@@ -159,7 +159,7 @@ with any testing framework and runner you're comfortable with.
     import '@testing-library/jest-dom';
     ```
 
-6.  Create your component + test file (checkout the rest of the docs to see how)
+6.  Create your component and a test file (checkout the rest of the docs to see how)
     and run the following command to run the tests.
 
     ```

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -118,7 +118,7 @@ with any testing framework and runner you're comfortable with.
     ```
 
 3.  You'll need to compile the Svelte components before using them in Vitest, so
-    we need to install
+    you need to install
     [@sveltejs/vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) & Vite
     
 


### PR DESCRIPTION
I work extensively in Svelte and I can say without a doubt that using Vitest over Jest is highly preferred since almost all Svelte build tools leverage Vite to build and, Svelte has a high preference for ES6 modules which Jest has a hard time handling.  I thought it would be helpful to update these docs for Svelte users with Vitest instructions since that will most likely be their preferred way of consuming this library. 

Also, let me know if you want me to reorganize things as I can see how people would get confused by the Typescript and preprocessors section which are specific to Jest right after the Vitest instructions. 

Minor Note: Sveltekit has its own setup with https://github.com/nickbreaton/vitest-svelte-kit
Do we want to add a section for this too?