### PR TITLE
Svelte: Update documentation for current best practices

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -373,8 +373,8 @@ screen.debug(screen.getAllByText('multi-test'))
 ### `screen.logTestingPlaygroundURL()`
 
 For debugging using [testing-playground](https://testing-playground.com), screen
-exposes this convenient method which logs and returns a URL that can be opened
-in a browser.
+exposes this convenient method which logs and returns a URL that can be opened in
+a browser.
 
 ```javascript
 import {screen} from '@testing-library/dom'

--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -188,7 +188,8 @@ React Testing Library re-export `screen` so you can use it the same way.
 Here's how you use it:
 
 <Tabs defaultValue="native" values={[ { label: 'Native', value: 'native', }, {
-label: 'React', value: 'react', }, { label: 'Cypress', value: 'cypress', }, ] }>
+label: 'React', value: 'react', }, { label: 'Cypress', value: 'cypress', },
+{ label: 'Svelte', value: 'svelte', }, ] }>
 <TabItem value="native">
 
 ```js
@@ -223,6 +224,21 @@ const exampleInput = screen.getByLabelText('Example')
 
 ```js
 cy.findByLabelText('Example').should('exist')
+```
+
+  </TabItem>
+  <TabItem value="svelte">
+```js
+// Comp.svelte
+<div>
+  <label htmlFor="example">Example</label>
+  <input id="example" />
+</div>
+
+// comp.test.js
+import {render, screen} from '@testing-library/svelte'
+
+const exampleInput = screen.getByLabelText('Example')
 ```
 
   </TabItem>

--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -189,7 +189,7 @@ Here's how you use it:
 
 <Tabs defaultValue="native" values={[ { label: 'Native', value: 'native', }, {
 label: 'React', value: 'react', }, { label: 'Cypress', value: 'cypress', },
-{ label: 'Svelte', value: 'svelte', }, ] }>
+{ label: 'Svelte', value: 'svelte', },] }>
 <TabItem value="native">
 
 ```js
@@ -228,14 +228,8 @@ cy.findByLabelText('Example').should('exist')
 
   </TabItem>
   <TabItem value="svelte">
-```js
-// Comp.svelte
-<div>
-  <label htmlFor="example">Example</label>
-  <input id="example" />
-</div>
 
-// comp.test.js
+```js
 import {render, screen} from '@testing-library/svelte'
 
 const exampleInput = screen.getByLabelText('Example')
@@ -389,8 +383,8 @@ screen.debug(screen.getAllByText('multi-test'))
 ### `screen.logTestingPlaygroundURL()`
 
 For debugging using [testing-playground](https://testing-playground.com), screen
-exposes this convenient method which logs and returns a URL that can be opened in
-a browser.
+exposes this convenient method which logs and returns a URL that can be opened
+in a browser.
 
 ```javascript
 import {screen} from '@testing-library/dom'

--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -188,8 +188,7 @@ React Testing Library re-export `screen` so you can use it the same way.
 Here's how you use it:
 
 <Tabs defaultValue="native" values={[ { label: 'Native', value: 'native', }, {
-label: 'React', value: 'react', }, { label: 'Cypress', value: 'cypress', },
-{ label: 'Svelte', value: 'svelte', },] }>
+label: 'React', value: 'react', }, { label: 'Cypress', value: 'cypress', }, ] }>
 <TabItem value="native">
 
 ```js
@@ -224,15 +223,6 @@ const exampleInput = screen.getByLabelText('Example')
 
 ```js
 cy.findByLabelText('Example').should('exist')
-```
-
-  </TabItem>
-  <TabItem value="svelte">
-
-```js
-import {render, screen} from '@testing-library/svelte'
-
-const exampleInput = screen.getByLabelText('Example')
 ```
 
   </TabItem>

--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -6,7 +6,6 @@ sidebar_label: API
 
 - [`@testing-library/dom`](#testing-library-dom)
 - [`render`](#render)
-- [`screen`](#screen)
 - [`cleanup`](#cleanup)
 - [`act`](#act-async)
 - [`fireEvent`](#fireevent-async)

--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -30,6 +30,29 @@ import {render} from '@testing-library/svelte'
 const {results} = render(YourComponent, {ComponentOptions}, {RenderOptions})
 ```
 
+## `screen`
+
+All of the queries exported by DOM Testing Library accept a `container` as the
+first argument. Because querying the entire `document.body` is very common, DOM
+Testing Library also exports a `screen` object which has every query that is
+pre-bound to `document.body` (using the
+[`within`](dom-testing-library/api-within.mdx) functionality). Wrappers such as
+React Testing Library re-export `screen` so you can use it the same way.
+
+```js
+import {render, screen} from '@testing-library/svelte'
+
+render(YourComponent, {ComponentOptions}, {RenderOptions})
+const result = screen.getByText('value');
+```
+> **Note**
+>
+> You need a global DOM environment to use `screen`. If you're using jest,
+> with the [testEnvironment](https://jestjs.io/docs/en/configuration#testenvironment-string)
+> set to `jsdom`, a global DOM environment will be available for you.
+>
+> Detailed examples using screen can be viewed at [About Queries](https://testing-library.com/docs/queries/about/#screen)
+
 ### Component Options
 
 These are the options you pass when instantiating your Svelte `Component`.
@@ -41,13 +64,13 @@ in directly.
 
 ```js
 // With options.
-const {results} = render(YourComponent, {
+render(YourComponent, {
   target: MyTarget,
-  props: {myProp: 'value'},
+  props: { myProp: 'value' },
 })
 
 // Props only.
-const {results} = render(YourComponent, {myProp: 'value'})
+render(YourComponent, { myProp: 'value' })
 ```
 
 ### Render Options
@@ -128,22 +151,22 @@ import {render, fireEvent} from '@testing-library/svelte'
 import Comp from '..'
 
 test('count increments when button is clicked', async () => {
-  const {getByText} = render(Comp)
-  const button = getByText('Count is 0')
+  render(Comp);
+  const button = screen.getByText('Count is 0');
 
   // Option 1.
-  await fireEvent.click(button)
-  expect(button).toHaveTextContent('Count is 1')
+  await fireEvent.click(button);
+  expect(button).toHaveTextContent('Count is 1');
 
   // Option 2.
   await fireEvent(
-    button,
-    new MouseEvent('click', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  )
-  expect(button).toHaveTextContent('Count is 2')
+      button,
+      new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+      }),
+  );
+  expect(button).toHaveTextContent('Count is 2');
 })
 ```
 

--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -31,32 +31,6 @@ import {render} from '@testing-library/svelte'
 const {results} = render(YourComponent, {ComponentOptions}, {RenderOptions})
 ```
 
-## `screen`
-
-All of the queries exported by DOM Testing Library accept a `container` as the
-first argument. Because querying the entire `document.body` is very common, DOM
-Testing Library also exports a `screen` object which has every query that is
-pre-bound to `document.body` (using the
-[`within`](dom-testing-library/api-within.mdx) functionality). Wrappers such as
-React Testing Library re-export `screen` so you can use it the same way.
-
-```js
-import {render, screen} from '@testing-library/svelte'
-
-render(YourComponent, {ComponentOptions}, {RenderOptions})
-const result = screen.getByText('value')
-```
-
-> **Note**
->
-> You need a global DOM environment to use `screen`. If you're using jest, with
-> the
-> [testEnvironment](https://jestjs.io/docs/en/configuration#testenvironment-string)
-> set to `jsdom`, a global DOM environment will be available for you.
->
-> Detailed examples using screen can be viewed at
-> [About Queries](https://testing-library.com/docs/queries/about/#screen)
-
 ### Component Options
 
 These are the options you pass when instantiating your Svelte `Component`.
@@ -150,7 +124,7 @@ changes.
 ```js
 import '@testing-library/jest-dom'
 
-import {render, fireEvent} from '@testing-library/svelte'
+import {render, fireEvent, screen} from '@testing-library/svelte'
 
 import Comp from '..'
 

--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -6,6 +6,7 @@ sidebar_label: API
 
 - [`@testing-library/dom`](#testing-library-dom)
 - [`render`](#render)
+- [`screen`](#screen)
 - [`cleanup`](#cleanup)
 - [`act`](#act-async)
 - [`fireEvent`](#fireevent-async)
@@ -43,15 +44,18 @@ React Testing Library re-export `screen` so you can use it the same way.
 import {render, screen} from '@testing-library/svelte'
 
 render(YourComponent, {ComponentOptions}, {RenderOptions})
-const result = screen.getByText('value');
+const result = screen.getByText('value')
 ```
+
 > **Note**
 >
-> You need a global DOM environment to use `screen`. If you're using jest,
-> with the [testEnvironment](https://jestjs.io/docs/en/configuration#testenvironment-string)
+> You need a global DOM environment to use `screen`. If you're using jest, with
+> the
+> [testEnvironment](https://jestjs.io/docs/en/configuration#testenvironment-string)
 > set to `jsdom`, a global DOM environment will be available for you.
 >
-> Detailed examples using screen can be viewed at [About Queries](https://testing-library.com/docs/queries/about/#screen)
+> Detailed examples using screen can be viewed at
+> [About Queries](https://testing-library.com/docs/queries/about/#screen)
 
 ### Component Options
 
@@ -64,13 +68,13 @@ in directly.
 
 ```js
 // With options.
-render(YourComponent, {
+const {results} = render(YourComponent, {
   target: MyTarget,
-  props: { myProp: 'value' },
+  props: {myProp: 'value'},
 })
 
 // Props only.
-render(YourComponent, { myProp: 'value' })
+const {results} = render(YourComponent, {myProp: 'value'})
 ```
 
 ### Render Options
@@ -151,22 +155,22 @@ import {render, fireEvent} from '@testing-library/svelte'
 import Comp from '..'
 
 test('count increments when button is clicked', async () => {
-  render(Comp);
-  const button = screen.getByText('Count is 0');
+  render(Comp)
+  const button = screen.getByText('Count is 0')
 
   // Option 1.
-  await fireEvent.click(button);
-  expect(button).toHaveTextContent('Count is 1');
+  await fireEvent.click(button)
+  expect(button).toHaveTextContent('Count is 1')
 
   // Option 2.
   await fireEvent(
-      button,
-      new MouseEvent('click', {
-          bubbles: true,
-          cancelable: true,
-      }),
-  );
-  expect(button).toHaveTextContent('Count is 2');
+    button,
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  )
+  expect(button).toHaveTextContent('Count is 2')
 })
 ```
 

--- a/docs/svelte-testing-library/example.mdx
+++ b/docs/svelte-testing-library/example.mdx
@@ -28,20 +28,20 @@ sidebar_label: Example
 // NOTE: jest-dom adds handy assertions to Jest and it is recommended, but not required.
 import '@testing-library/jest-dom'
 
-import {render, fireEvent} from '@testing-library/svelte'
+import {render, fireEvent, screen} from '@testing-library/svelte'
 
 import Comp from '../Comp'
 
 test('shows proper heading when rendered', () => {
-  const {getByText} = render(Comp, {name: 'World'})
-
-  expect(getByText('Hello World!')).toBeInTheDocument()
+  render(Comp, { name: 'World' })
+  const heading = screen.getByText("Hello World!");
+  expect(heading).toBeInTheDocument();
 })
 
 // Note: This is as an async test as we are using `fireEvent`
 test('changes button text on click', async () => {
-  const {getByText} = render(Comp, {name: 'World'})
-  const button = getByText('Button')
+  render(Comp, { name: 'World' })
+  const button = screen.getByRole("button")
 
   // Using await when firing events is unique to the svelte testing library because
   // we have to wait for the next `tick` so that Svelte flushes all pending state changes.


### PR DESCRIPTION
The original Testing Library/Svelte docs have not beed updated in quite a while and I believe the actual examples were written prior to `screen` being released in [DOM Testing Library v6.11.0](https://github.com/testing-library/dom-testing-library/releases/tag/v6.11.0). 

Best practice is to use the `screen` and not access the `container` directly for queries.