### PR TITLE
docs: remove exact prop in v6 Route example

### DIFF
--- a/docs/example-react-router.mdx
+++ b/docs/example-react-router.mdx
@@ -27,7 +27,7 @@ export const App = () => (
     <Link to="/about">About</Link>
 
     <Routes>
-      <Route exact path="/" element={<Home />} />
+      <Route path="/" element={<Home />} />
 
       <Route path="/about" element={<About />} />
 


### PR DESCRIPTION
No Need for exact in Route of v6. it acts as exact by default.