### PR TITLE
Update Svelte Setup to reflect current preferred testing framework

### DIFF
--- a/docs/svelte-testing-library/intro.mdx
+++ b/docs/svelte-testing-library/intro.mdx
@@ -41,4 +41,4 @@ Introduction][dom-solution-explainer] for a more in-depth explanation.
 1.  A test runner or framework.
 2.  Specific to a testing framework.
 
-We recommend Jest as our preference.
+We recommend Vitest as our preference.

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -4,8 +4,79 @@ title: Setup
 sidebar_label: Setup
 ---
 
-We recommend using [Jest](https://jestjs.io) but you're free to use the library
+We recommend using [Vitest](https://vitest.dev/) but you're free to use the library
 with any testing framework and runner you're comfortable with.
+
+## Vitest
+1.  Install Vitest and jsdom
+
+    ```
+    npm install --save-dev vitest jsdom
+    ```
+
+2.  Add the following to your `package.json`
+
+    ```json
+    {
+      "scripts": {
+        "test": "vitest run src",
+        "test:watch": "vitest src"
+      }
+    }
+    ```
+
+3.  You'll need to compile the Svelte components before using them in Vitest, so
+    you need to install
+    [@sveltejs/vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) and Vite
+    
+
+    ```
+    npm install --save-dev @sveltejs/vite-plugin-svelte vite
+    ```
+
+4.  Add a `vitest.config.ts` configuration file to the root of your project
+
+    ```js
+    import { defineConfig } from 'vite';
+    import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+    export default defineConfig({
+        plugins: [svelte({ hot: !process.env.VITEST })],
+        test: {
+            include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+            globals: true,
+            environment: 'jsdom'
+        }
+    });
+
+    ```
+
+5.  This is optional but it is recommended, you can install
+    [jest-dom](https://github.com/testing-library/jest-dom) to add handy
+    assertions to Jest
+
+    5.1 Install `jest-dom`
+
+    ```
+    npm install --save-dev @testing-library/jest-dom
+    ```
+
+    5.2 import `@testing-library/jest-dom` at the start of your test files
+
+    ```js
+    import '@testing-library/jest-dom';
+    ```
+
+6.  Create your component and a test file (checkout the rest of the docs to see how)
+    and run the following command to run the tests.
+
+    ```
+    npm run test
+    ```  
+### SvelteKit
+
+If you want to use Vitest with SvelteKit you can install `vitest-svelte-kit` which includes a preconfigured Vitest configuration for SvelteKit projects.
+To install simply follow the instructions over at [vitest-svelte-kit](https://github.com/nickbreaton/vitest-svelte-kit/tree/master/packages/vitest-svelte-kit)
 
 ## Jest
 
@@ -99,79 +170,14 @@ with any testing framework and runner you're comfortable with.
     ```
     npm run test
     ```
-## Vitest
-1.  Install Vitest and jsdom
 
-    ```
-    npm install --save-dev vitest jsdom
-    ```
+### Typescript
 
-2.  Add the following to your `package.json`
-
-    ```json
-    {
-      "scripts": {
-        "test": "vitest run src",
-        "test:watch": "vitest src"
-      }
-    }
-    ```
-
-3.  You'll need to compile the Svelte components before using them in Vitest, so
-    you need to install
-    [@sveltejs/vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) and Vite
-    
-
-    ```
-    npm install --save-dev @sveltejs/vite-plugin-svelte vite
-    ```
-
-4.  Add a `vitest.config.ts` configuration file to the root of your project
-
-    ```js
-    import { defineConfig } from 'vite';
-    import { svelte } from '@sveltejs/vite-plugin-svelte';
-
-    export default defineConfig({
-        plugins: [svelte({ hot: !process.env.VITEST })],
-        test: {
-            include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-            globals: true,
-            environment: 'jsdom'
-        }
-    });
-
-    ```
-
-5.  This is optional but it is recommended, you can install
-    [jest-dom](https://github.com/testing-library/jest-dom) to add handy
-    assertions to Jest
-
-    5.1 Install `jest-dom`
-
-    ```
-    npm install --save-dev @testing-library/jest-dom
-    ```
-
-    5.2 import `@testing-library/jest-dom` at the start of your test files
-
-    ```js
-    import '@testing-library/jest-dom';
-    ```
-
-6.  Create your component and a test file (checkout the rest of the docs to see how)
-    and run the following command to run the tests.
-
-    ```
-    npm run test
-    ```
-## Typescript
-
-To use Typescript, you'll need to install and configure `svelte-preprocess` and
+To use Typescript with Jest, you'll need to install and configure `svelte-preprocess` and
 `ts-jest`. For full instructions, see the
 [`svelte-jester`](https://github.com/mihar-22/svelte-jester#typescript) docs.
 
-## Preprocessors
+### Preprocessors
 
 If you'd like to also include any
 [Svelte preprocessors](https://github.com/sveltejs/svelte-preprocess) then

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -75,7 +75,7 @@ with any testing framework and runner you're comfortable with.
     ```  
 ### SvelteKit
 
-If you want to use Vitest with SvelteKit you can install `vitest-svelte-kit` which includes a preconfigured Vitest configuration for SvelteKit projects.
+To use Vitest with SvelteKit install `vitest-svelte-kit`, which includes a preconfigured Vitest configuration for SvelteKit projects.
 You can take a look at the [`vitest-svelte-kit` configuration docs](https://github.com/nickbreaton/vitest-svelte-kit/tree/master/packages/vitest-svelte-kit#configuring) for further instructions.
 
 ## Jest

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -76,7 +76,7 @@ with any testing framework and runner you're comfortable with.
 ### SvelteKit
 
 If you want to use Vitest with SvelteKit you can install `vitest-svelte-kit` which includes a preconfigured Vitest configuration for SvelteKit projects.
-To install simply follow the instructions over at [vitest-svelte-kit](https://github.com/nickbreaton/vitest-svelte-kit/tree/master/packages/vitest-svelte-kit)
+You can take a look at the [`vitest-svelte-kit` configuration docs](https://github.com/nickbreaton/vitest-svelte-kit/tree/master/packages/vitest-svelte-kit#configuring) for further instructions.
 
 ## Jest
 


### PR DESCRIPTION
After my last update I talked with some of the guys on the Svelte discord and its pretty well accepted that Vitest is the preferred unit testing framework for Svelte. Please refer to the comment from @benmccann  at the bottom of this [issue](https://github.com/sveltejs/kit/issues/4423)

So I updated the Setup docs to put Vitest as the preferred. I also added a section for the Sveltekit plugin for people using Sveltekit. 

As for the Jest Section I moved it to the bottom and I set the Typescript and preprocess sections as subsections since those are Jest specific. I was wondering if I should add sections like those to the Vitest section? The svelte-vite-plugin simply just reads your svelte.config.  So if you were already building the project in TS or using preprocessors you don't need to do anything. So idk if it is worth mentioning. Let me know. 

Thanks Dudes!