### PR TITLE
update docusaurus version 2

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -200,10 +200,6 @@ module.exports = {
         pinned: false,
       },
     ],
-    fonts: {
-      fontMain: ['Source Sans Pro', 'sans-serif'],
-      fontCode: ['IBM Plex Mono', 'monospace'],
-    },
     repoUrl: 'https://github.com/testing-library/dom-testing-library',
     docsRepoUrl: 'https://github.com/testing-library/testing-library-docs',
     docsPath: 'docs',
@@ -224,13 +220,12 @@ module.exports = {
         blog: {
           path: './blog',
           blogSidebarCount: 'ALL',
-          blogSidebarTitle: 'All posts',
           feedOptions: {
             type: 'all',
           },
         },
         theme: {
-          customCss: require.resolve('./src/css/custom.css'),
+          customCss: [require.resolve('./src/css/custom.css')],
         },
         gtag: {
           trackingID: 'UA-137787095-1',
@@ -249,6 +244,7 @@ module.exports = {
     navbar: {
       title: 'Testing Library',
       logo: {
+        alt: 'An octopus representing the DOM Testing Library Logo',
         src: 'img/octopus-64x64.png',
       },
       items: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
       "name": "react-testing-library-docs",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "^2.0.0-rc.1",
-        "@docusaurus/preset-classic": "^2.0.0-rc.1",
+        "@docusaurus/core": "^2.0.1",
+        "@docusaurus/preset-classic": "^2.0.1",
         "classnames": "^2.3.1",
         "clsx": "^1.1.1",
         "react": "^16.10.2",
@@ -48,74 +48,74 @@
       "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.1.tgz",
-      "integrity": "sha512-BBdibsPn3hLBajc/NRAtHEeoXsw+ziSGR/3bqRNB5puUuwKPQZSE2MaMVWSADnlc3KV3bEj4xsfKOVLJyfJSPQ==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
+      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.1"
+        "@algolia/cache-common": "4.14.2"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.1.tgz",
-      "integrity": "sha512-XhAzm0Sm3D3DuOWUyDoVSXZ/RjYMvI1rbki+QH4ODAVaHDWVhMhg3IJPv3gIbBQnEQdtPdBhsf2hyPxAu28E5w=="
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
+      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.1.tgz",
-      "integrity": "sha512-fVUu7N1hYb/zZYfV9Krlij70NwS+8bQm5vmDJyfp0+9FjSjz2V7wj1CUxvaY8ZcgoBPj9ehQ8sRuqSM2m5OPww==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
+      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.1"
+        "@algolia/cache-common": "4.14.2"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.1.tgz",
-      "integrity": "sha512-Zm4+PN3bsBPhv1dKKwzBaRGzf0G1JcjjSTpE231L7Z7LsEDcFDW4E6L5ctwMz3SliSBeL/j1ghmaunJrZlkRIg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
+      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
       "dependencies": {
-        "@algolia/client-common": "4.14.1",
-        "@algolia/client-search": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.1.tgz",
-      "integrity": "sha512-EhZLR0ezBZx7ZGkwzj7OTvnI8j2Alyv1ByC0Mx48qh3KqRhVwMFm/Uf34zAv4Dum2PTFin41Y4smAvAypth9nQ==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
+      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
       "dependencies": {
-        "@algolia/client-common": "4.14.1",
-        "@algolia/client-search": "4.14.1",
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.1.tgz",
-      "integrity": "sha512-WDwziD7Rt1yCRDfONmeLOfh1Lt8uOy6Vn7dma171KOH9NN3q8yDQpOhPqdFOCz1j3GC1FfIZxaC0YEOIobZ2lg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
+      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.1.tgz",
-      "integrity": "sha512-D4eeW7bTi769PWcEYZO+QiKuUXFOC5zK5Iy83Ey6FHqS7m5TXws5MP1rmETE018lTXeYq2NSHWp/F07fRRg0RA==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
+      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
       "dependencies": {
-        "@algolia/client-common": "4.14.1",
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.1.tgz",
-      "integrity": "sha512-K6XrdIIQq8a3o+kCedj5slUVzA1aKttae4mLzwnY0bS7tYduv1IQggi9Sz8gOG6/MMyKMB4IwYqr47t/0z4Vxw==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
+      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
       "dependencies": {
-        "@algolia/client-common": "4.14.1",
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "node_modules/@algolia/events": {
@@ -124,47 +124,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.1.tgz",
-      "integrity": "sha512-58CK87wTjUWI1QNXc3nFDQ7EXBi28NoLufXE9sMjng2fAL1wPdyO+KFD8KTBoXOZnJWflPj5F7p6jLyGAfgvcQ=="
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
+      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.1.tgz",
-      "integrity": "sha512-not+VwH1Dx2B/BaN+4+4+YnGRBJ9lduNz2qbMCTxZ4yFHb+84j4ewHRPBTtEmibn7caVCPybdTKfHLQhimSBLQ==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
+      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
       "dependencies": {
-        "@algolia/logger-common": "4.14.1"
+        "@algolia/logger-common": "4.14.2"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.1.tgz",
-      "integrity": "sha512-mpH6QsFBbXjTy9+iU86Rcdt9LxS7GA/tWhGMr0+Ap8+4Za5+ELToz0PC7euVeVOcclgGGi7gbjOAmf6k8b10iA==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
+      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.1"
+        "@algolia/requester-common": "4.14.2"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.1.tgz",
-      "integrity": "sha512-EbXBKrfYcX5/JJfaw7IZxhWlbUtjd5Chs+Alrfc4tutgRQn4dmImWS07n3iffwJcYdOWY1eRrnfBK5BwopuN5A=="
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
+      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.1.tgz",
-      "integrity": "sha512-/sbRqL9P8aVuYUG50BgpCbdJyyCS7fia+sQIx9d1DiGPO7hunwLaEyR4H7JDHc/PLKdVEPygJx3rnbJWix4Btg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
+      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.1"
+        "@algolia/requester-common": "4.14.2"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.1.tgz",
-      "integrity": "sha512-xbmoIqszFDOCCZqizBQ2TNHcGtjZX7EkJCzABsrokA0WqtfZzClFmtc+tZYgtEiyAfIF70alTegG19poQGdkvg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
+      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.1",
-        "@algolia/logger-common": "4.14.1",
-        "@algolia/requester-common": "4.14.1"
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2014,18 +2014,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
-      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.0.tgz",
+      "integrity": "sha512-jnNrO2JVYYhj2pP2FomlHIy6220n6mrLn2t9v2/qc+rM7M/fbIcKMgk9ky4RN+L/maUEmteckzg6/PIYoAAXJg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
-      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.0.tgz",
+      "integrity": "sha512-ATS3w5JBgQGQF0kHn5iOAPfnCCaoLouZQMmI7oENV//QMFrYbjhUZxBU9lIwAT7Rzybud+Jtb4nG5IEjBk3Ixw==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.7.1",
         "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.1.1",
+        "@docsearch/css": "3.2.0",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -2035,9 +2035,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-b9FX0Z+EddfQ6wAiNh+Wx4fysKfcvEcWJrZ5USROn3C+EVU5P4luaa8mwWK//O+hTwD9ur7/A44IZ/tWCTAoLQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -2049,13 +2049,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
+        "@docusaurus/cssnano-preset": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-common": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2368,9 +2368,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-rc.1.tgz",
-      "integrity": "sha512-9/KmQvF+eTlMqUqG6UcXbRgxbGed/8bQInXuKEs+95/jI6jO/3xSzuRwuHHHP0naUvSVWjnNI9jngPrQerXE5w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+      "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2387,9 +2387,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-rc.1.tgz",
-      "integrity": "sha512-daa3g+SXuO9K60PVMiSUmDEK9Vro+Ed7i7uF8CH6QQJLcNZy/zJc0Xz62eH7ip1x77fmeb6Rg4Us1TqTFc9AbQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2404,14 +2404,14 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-rc.1.tgz",
-      "integrity": "sha512-8Fg0c/ceu39knmr7w0dutm7gq3YxKYCqWVS2cB/cPATzChCCNH/AGLfBT6sz/Z4tjVXE+NyREq2pfOFvkhjVXg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz",
+      "integrity": "sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2440,12 +2440,12 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-rc.1.tgz",
-      "integrity": "sha512-la7D8ggFP8I5nOp/Epl6NqTeDWcbofPVMOaVisRxQbx5iuF9Al+AITbaDgm4CXpFLJACsqhsXD5W4BnKX8ZxfA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz",
+      "integrity": "sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.0.0-rc.1",
+        "@docusaurus/types": "2.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2459,17 +2459,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-rc.1.tgz",
-      "integrity": "sha512-BVVrAGZujpjS/0rarY2o24rlylRRh2NZuM65kg0JNkkViF79SeEHsepog7IuHyoqGWPm1N/I7LpEp7k+gowZzQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz",
+      "integrity": "sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-common": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2494,17 +2494,17 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-rc.1.tgz",
-      "integrity": "sha512-Yk5Hu6uaw3tRplzJnbDygwRhmZ3PCzEXD4SJpBA6cPC73ylfqOEh6qhiU+BWhMTtDXNhY+athk5Kycfk3DW1aQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz",
+      "integrity": "sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/module-type-aliases": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2568,15 +2568,15 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-rc.1.tgz",
-      "integrity": "sha512-FdO79WC5hfWDQu3/CTFLRQzTNc0e5n+HNzavm2MNkSzGV08BFJ6RAkbPbtra5CWef+6iXZav6D/tzv2jDPvLzA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz",
+      "integrity": "sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2595,13 +2595,13 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-rc.1.tgz",
-      "integrity": "sha512-aOsyYrPMbnsyqHwsVZ+0frrMRtnYqm4eaJpG4sC/6LYAJ07IDRQ9j3GOku2dKr5GsFK1Vx7VlE6ZLwe0MaGstg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz",
+      "integrity": "sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2620,13 +2620,13 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-rc.1.tgz",
-      "integrity": "sha512-f+G8z5OJWfg5QqWDLIdcN2SDoK5J5Gg8HMrqCI6Pfl+rxPb5I1niA+/UkAM+kMCpnekvhSt5AWz2fgkRenkPLA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz",
+      "integrity": "sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2643,13 +2643,13 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-rc.1.tgz",
-      "integrity": "sha512-yE1Et9hhhX9qMRnMJzpNq0854qIYiSEc2dZaXNk537HN7Q0rKkr/YONUHz2iqNYwPX2hGOY4LdpTxlMP88uVhA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz",
+      "integrity": "sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2666,16 +2666,16 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-rc.1.tgz",
-      "integrity": "sha512-5JmbNpssUF03odFM4ArvIsrO9bv7HnAJ0VtefXhh0WBpaFs8NgI3rTkCTFimvtRQjDR9U2bh23fXz2vjQQz6oA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz",
+      "integrity": "sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-common": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2694,22 +2694,22 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-rc.1.tgz",
-      "integrity": "sha512-5jjTVZkhArjyoNHwCI9x4PSG0zPmBJILjZLVrxPcHpm/K0ltkYcp6J3GxYpf5EbMuOh5+yCWM63cSshGcNOo3Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz",
+      "integrity": "sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-blog": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-docs": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-pages": "2.0.0-rc.1",
-        "@docusaurus/plugin-debug": "2.0.0-rc.1",
-        "@docusaurus/plugin-google-analytics": "2.0.0-rc.1",
-        "@docusaurus/plugin-google-gtag": "2.0.0-rc.1",
-        "@docusaurus/plugin-sitemap": "2.0.0-rc.1",
-        "@docusaurus/theme-classic": "2.0.0-rc.1",
-        "@docusaurus/theme-common": "2.0.0-rc.1",
-        "@docusaurus/theme-search-algolia": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1"
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/plugin-debug": "2.0.1",
+        "@docusaurus/plugin-google-analytics": "2.0.1",
+        "@docusaurus/plugin-google-gtag": "2.0.1",
+        "@docusaurus/plugin-sitemap": "2.0.1",
+        "@docusaurus/theme-classic": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-search-algolia": "2.0.1",
+        "@docusaurus/types": "2.0.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -2732,22 +2732,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-rc.1.tgz",
-      "integrity": "sha512-qNiz7ieeq3AC+V8TbW6S63pWLJph1CbzWDDPTqxDLHgA8VQaNaSmJM8S92pH+yKALRb9u14ogjjYYc75Nj2JmQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz",
+      "integrity": "sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/module-type-aliases": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-blog": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-docs": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-pages": "2.0.0-rc.1",
-        "@docusaurus/theme-common": "2.0.0-rc.1",
-        "@docusaurus/theme-translations": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-common": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-translations": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -2776,16 +2776,16 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-rc.1.tgz",
-      "integrity": "sha512-1r9ZLKD9SeoCYVzWzcdR79Dia4ANlrlRjNl6uzETOEybjK6FF7yEa9Yra8EJcOCbi3coyYz5xFh/r1YHFTFHug==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.1.tgz",
+      "integrity": "sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/module-type-aliases": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-blog": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-docs": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-pages": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2809,18 +2809,18 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-rc.1.tgz",
-      "integrity": "sha512-H5yq6V/B4qo6GZrDKMbeSpk3T9e9K2MliDzLonRu0w3QHW9orVGe0c/lZvRbGlDZjnsOo7XGddhXXIDWGwnpaA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz",
+      "integrity": "sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-docs": "2.0.0-rc.1",
-        "@docusaurus/theme-common": "2.0.0-rc.1",
-        "@docusaurus/theme-translations": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-translations": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -2844,9 +2844,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-rc.1.tgz",
-      "integrity": "sha512-JLhNdlnbQhxVQzOnLyiCaTzKFa1lpVrM3nCrkGQKscoG2rY6ARGYMgMN2DkoH6hm7TflQ8+PE1S5MzzASeLs4Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz",
+      "integrity": "sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2861,9 +2861,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-rc.1.tgz",
-      "integrity": "sha512-wX25FOZa/aKnCGA5ljWPaDpMW3TuTbs0BtjQ8WTC557p8zDvuz4r+g2/FPHsgWE0TKwUMf4usQU1m3XpJLPN+g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2888,11 +2888,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ym9I1OwIYbKs1LGaUajaA/vDG8VweJj/6YoZjHp+eDQHhTRIrHXiYoGDqorafRhftKwnA1EnyomuXpNd9bq8Gg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz",
+      "integrity": "sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.0-rc.1",
+        "@docusaurus/logger": "2.0.1",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -2921,9 +2921,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-rc.1.tgz",
-      "integrity": "sha512-+iZICpeFPZJ9oGJXuG92WTWee6WRnVx5BdzlcfuKf/f5KQX8PvwXR2tDME78FGGhShB8zr+vjuNEXuLvXT7j2A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz",
+      "integrity": "sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2945,12 +2945,12 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-rc.1.tgz",
-      "integrity": "sha512-lj36gm9Ksu4tt/EUeLDWoMbXe3sfBxeIPIUUdqYcBYkF/rpQkh+uL/dncjNGiw6uvBOqXhOfsFVP045HtgShVw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz",
+      "integrity": "sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -6046,30 +6046,30 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.1.tgz",
-      "integrity": "sha512-ZWqnbsGUgU03/IyG995pMCc+EmNVDA/4c9ntr8B0dWQwFqazOQ4ErvKZxarbgSNmyPo/eZcVsTb0bNplJMttGQ==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
+      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.14.1",
-        "@algolia/cache-common": "4.14.1",
-        "@algolia/cache-in-memory": "4.14.1",
-        "@algolia/client-account": "4.14.1",
-        "@algolia/client-analytics": "4.14.1",
-        "@algolia/client-common": "4.14.1",
-        "@algolia/client-personalization": "4.14.1",
-        "@algolia/client-search": "4.14.1",
-        "@algolia/logger-common": "4.14.1",
-        "@algolia/logger-console": "4.14.1",
-        "@algolia/requester-browser-xhr": "4.14.1",
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/requester-node-http": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/cache-browser-local-storage": "4.14.2",
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/cache-in-memory": "4.14.2",
+        "@algolia/client-account": "4.14.2",
+        "@algolia/client-analytics": "4.14.2",
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-personalization": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/logger-console": "4.14.2",
+        "@algolia/requester-browser-xhr": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/requester-node-http": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
-      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
+      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -6556,9 +6556,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.7",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
-      "integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.8.tgz",
+      "integrity": "sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==",
       "funding": [
         {
           "type": "opencollective",
@@ -6570,8 +6570,8 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.20.3",
-        "caniuse-lite": "^1.0.30001335",
+        "browserslist": "^4.21.3",
+        "caniuse-lite": "^1.0.30001373",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -7489,9 +7489,9 @@
       ]
     },
     "node_modules/browserslist": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
-      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "version": "4.21.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
+      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7503,10 +7503,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001366",
-        "electron-to-chromium": "^1.4.188",
+        "caniuse-lite": "^1.0.30001370",
+        "electron-to-chromium": "^1.4.202",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.4"
+        "update-browserslist-db": "^1.0.5"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7724,9 +7724,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001369",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001369.tgz",
-      "integrity": "sha512-OY1SBHaodJc4wflDIKnlkdqWzJZd1Ls/2zbVJHBSv3AT7vgOJ58yAhd2CN4d57l2kPJrgMb7P9+N1Mhy4tNSQA==",
+      "version": "1.0.30001373",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10349,9 +10349,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.199",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.199.tgz",
-      "integrity": "sha512-WIGME0Cs7oob3mxsJwHbeWkH0tYkIE/sjkJ8ML2BYmuRcjhRl/q5kVDXG7W9LOOKwzPU5M0LBlXRq9rlSgnNlg=="
+      "version": "1.4.210",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
+      "integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ=="
     },
     "node_modules/elegant-spinner": {
       "version": "1.0.1",
@@ -27009,74 +27009,74 @@
       "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.1.tgz",
-      "integrity": "sha512-BBdibsPn3hLBajc/NRAtHEeoXsw+ziSGR/3bqRNB5puUuwKPQZSE2MaMVWSADnlc3KV3bEj4xsfKOVLJyfJSPQ==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
+      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
       "requires": {
-        "@algolia/cache-common": "4.14.1"
+        "@algolia/cache-common": "4.14.2"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.1.tgz",
-      "integrity": "sha512-XhAzm0Sm3D3DuOWUyDoVSXZ/RjYMvI1rbki+QH4ODAVaHDWVhMhg3IJPv3gIbBQnEQdtPdBhsf2hyPxAu28E5w=="
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
+      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.1.tgz",
-      "integrity": "sha512-fVUu7N1hYb/zZYfV9Krlij70NwS+8bQm5vmDJyfp0+9FjSjz2V7wj1CUxvaY8ZcgoBPj9ehQ8sRuqSM2m5OPww==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
+      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
       "requires": {
-        "@algolia/cache-common": "4.14.1"
+        "@algolia/cache-common": "4.14.2"
       }
     },
     "@algolia/client-account": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.1.tgz",
-      "integrity": "sha512-Zm4+PN3bsBPhv1dKKwzBaRGzf0G1JcjjSTpE231L7Z7LsEDcFDW4E6L5ctwMz3SliSBeL/j1ghmaunJrZlkRIg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
+      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
       "requires": {
-        "@algolia/client-common": "4.14.1",
-        "@algolia/client-search": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.1.tgz",
-      "integrity": "sha512-EhZLR0ezBZx7ZGkwzj7OTvnI8j2Alyv1ByC0Mx48qh3KqRhVwMFm/Uf34zAv4Dum2PTFin41Y4smAvAypth9nQ==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
+      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
       "requires": {
-        "@algolia/client-common": "4.14.1",
-        "@algolia/client-search": "4.14.1",
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "@algolia/client-common": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.1.tgz",
-      "integrity": "sha512-WDwziD7Rt1yCRDfONmeLOfh1Lt8uOy6Vn7dma171KOH9NN3q8yDQpOhPqdFOCz1j3GC1FfIZxaC0YEOIobZ2lg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
+      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
       "requires": {
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.1.tgz",
-      "integrity": "sha512-D4eeW7bTi769PWcEYZO+QiKuUXFOC5zK5Iy83Ey6FHqS7m5TXws5MP1rmETE018lTXeYq2NSHWp/F07fRRg0RA==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
+      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
       "requires": {
-        "@algolia/client-common": "4.14.1",
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "@algolia/client-search": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.1.tgz",
-      "integrity": "sha512-K6XrdIIQq8a3o+kCedj5slUVzA1aKttae4mLzwnY0bS7tYduv1IQggi9Sz8gOG6/MMyKMB4IwYqr47t/0z4Vxw==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
+      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
       "requires": {
-        "@algolia/client-common": "4.14.1",
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "@algolia/events": {
@@ -27085,47 +27085,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.1.tgz",
-      "integrity": "sha512-58CK87wTjUWI1QNXc3nFDQ7EXBi28NoLufXE9sMjng2fAL1wPdyO+KFD8KTBoXOZnJWflPj5F7p6jLyGAfgvcQ=="
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
+      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
     },
     "@algolia/logger-console": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.1.tgz",
-      "integrity": "sha512-not+VwH1Dx2B/BaN+4+4+YnGRBJ9lduNz2qbMCTxZ4yFHb+84j4ewHRPBTtEmibn7caVCPybdTKfHLQhimSBLQ==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
+      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
       "requires": {
-        "@algolia/logger-common": "4.14.1"
+        "@algolia/logger-common": "4.14.2"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.1.tgz",
-      "integrity": "sha512-mpH6QsFBbXjTy9+iU86Rcdt9LxS7GA/tWhGMr0+Ap8+4Za5+ELToz0PC7euVeVOcclgGGi7gbjOAmf6k8b10iA==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
+      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
       "requires": {
-        "@algolia/requester-common": "4.14.1"
+        "@algolia/requester-common": "4.14.2"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.1.tgz",
-      "integrity": "sha512-EbXBKrfYcX5/JJfaw7IZxhWlbUtjd5Chs+Alrfc4tutgRQn4dmImWS07n3iffwJcYdOWY1eRrnfBK5BwopuN5A=="
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
+      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.1.tgz",
-      "integrity": "sha512-/sbRqL9P8aVuYUG50BgpCbdJyyCS7fia+sQIx9d1DiGPO7hunwLaEyR4H7JDHc/PLKdVEPygJx3rnbJWix4Btg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
+      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
       "requires": {
-        "@algolia/requester-common": "4.14.1"
+        "@algolia/requester-common": "4.14.2"
       }
     },
     "@algolia/transporter": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.1.tgz",
-      "integrity": "sha512-xbmoIqszFDOCCZqizBQ2TNHcGtjZX7EkJCzABsrokA0WqtfZzClFmtc+tZYgtEiyAfIF70alTegG19poQGdkvg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
+      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
       "requires": {
-        "@algolia/cache-common": "4.14.1",
-        "@algolia/logger-common": "4.14.1",
-        "@algolia/requester-common": "4.14.1"
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2"
       }
     },
     "@ampproject/remapping": {
@@ -28378,25 +28378,25 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
-      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.0.tgz",
+      "integrity": "sha512-jnNrO2JVYYhj2pP2FomlHIy6220n6mrLn2t9v2/qc+rM7M/fbIcKMgk9ky4RN+L/maUEmteckzg6/PIYoAAXJg=="
     },
     "@docsearch/react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
-      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.0.tgz",
+      "integrity": "sha512-ATS3w5JBgQGQF0kHn5iOAPfnCCaoLouZQMmI7oENV//QMFrYbjhUZxBU9lIwAT7Rzybud+Jtb4nG5IEjBk3Ixw==",
       "requires": {
         "@algolia/autocomplete-core": "1.7.1",
         "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.1.1",
+        "@docsearch/css": "3.2.0",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-b9FX0Z+EddfQ6wAiNh+Wx4fysKfcvEcWJrZ5USROn3C+EVU5P4luaa8mwWK//O+hTwD9ur7/A44IZ/tWCTAoLQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -28408,13 +28408,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
+        "@docusaurus/cssnano-preset": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-common": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -28623,9 +28623,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-rc.1.tgz",
-      "integrity": "sha512-9/KmQvF+eTlMqUqG6UcXbRgxbGed/8bQInXuKEs+95/jI6jO/3xSzuRwuHHHP0naUvSVWjnNI9jngPrQerXE5w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+      "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -28641,9 +28641,9 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-rc.1.tgz",
-      "integrity": "sha512-daa3g+SXuO9K60PVMiSUmDEK9Vro+Ed7i7uF8CH6QQJLcNZy/zJc0Xz62eH7ip1x77fmeb6Rg4Us1TqTFc9AbQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -28657,14 +28657,14 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-rc.1.tgz",
-      "integrity": "sha512-8Fg0c/ceu39knmr7w0dutm7gq3YxKYCqWVS2cB/cPATzChCCNH/AGLfBT6sz/Z4tjVXE+NyREq2pfOFvkhjVXg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz",
+      "integrity": "sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -28688,12 +28688,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-rc.1.tgz",
-      "integrity": "sha512-la7D8ggFP8I5nOp/Epl6NqTeDWcbofPVMOaVisRxQbx5iuF9Al+AITbaDgm4CXpFLJACsqhsXD5W4BnKX8ZxfA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz",
+      "integrity": "sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.0.0-rc.1",
+        "@docusaurus/types": "2.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -28703,17 +28703,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-rc.1.tgz",
-      "integrity": "sha512-BVVrAGZujpjS/0rarY2o24rlylRRh2NZuM65kg0JNkkViF79SeEHsepog7IuHyoqGWPm1N/I7LpEp7k+gowZzQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz",
+      "integrity": "sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-common": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -28733,17 +28733,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-rc.1.tgz",
-      "integrity": "sha512-Yk5Hu6uaw3tRplzJnbDygwRhmZ3PCzEXD4SJpBA6cPC73ylfqOEh6qhiU+BWhMTtDXNhY+athk5Kycfk3DW1aQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz",
+      "integrity": "sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/module-type-aliases": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -28790,15 +28790,15 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-rc.1.tgz",
-      "integrity": "sha512-FdO79WC5hfWDQu3/CTFLRQzTNc0e5n+HNzavm2MNkSzGV08BFJ6RAkbPbtra5CWef+6iXZav6D/tzv2jDPvLzA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz",
+      "integrity": "sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==",
       "requires": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -28812,13 +28812,13 @@
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-rc.1.tgz",
-      "integrity": "sha512-aOsyYrPMbnsyqHwsVZ+0frrMRtnYqm4eaJpG4sC/6LYAJ07IDRQ9j3GOku2dKr5GsFK1Vx7VlE6ZLwe0MaGstg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz",
+      "integrity": "sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -28832,13 +28832,13 @@
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-rc.1.tgz",
-      "integrity": "sha512-f+G8z5OJWfg5QqWDLIdcN2SDoK5J5Gg8HMrqCI6Pfl+rxPb5I1niA+/UkAM+kMCpnekvhSt5AWz2fgkRenkPLA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz",
+      "integrity": "sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==",
       "requires": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
       },
       "dependencies": {
@@ -28850,13 +28850,13 @@
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-rc.1.tgz",
-      "integrity": "sha512-yE1Et9hhhX9qMRnMJzpNq0854qIYiSEc2dZaXNk537HN7Q0rKkr/YONUHz2iqNYwPX2hGOY4LdpTxlMP88uVhA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz",
+      "integrity": "sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
       },
       "dependencies": {
@@ -28868,16 +28868,16 @@
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-rc.1.tgz",
-      "integrity": "sha512-5JmbNpssUF03odFM4ArvIsrO9bv7HnAJ0VtefXhh0WBpaFs8NgI3rTkCTFimvtRQjDR9U2bh23fXz2vjQQz6oA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz",
+      "integrity": "sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-common": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -28891,22 +28891,22 @@
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-rc.1.tgz",
-      "integrity": "sha512-5jjTVZkhArjyoNHwCI9x4PSG0zPmBJILjZLVrxPcHpm/K0ltkYcp6J3GxYpf5EbMuOh5+yCWM63cSshGcNOo3Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz",
+      "integrity": "sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-blog": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-docs": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-pages": "2.0.0-rc.1",
-        "@docusaurus/plugin-debug": "2.0.0-rc.1",
-        "@docusaurus/plugin-google-analytics": "2.0.0-rc.1",
-        "@docusaurus/plugin-google-gtag": "2.0.0-rc.1",
-        "@docusaurus/plugin-sitemap": "2.0.0-rc.1",
-        "@docusaurus/theme-classic": "2.0.0-rc.1",
-        "@docusaurus/theme-common": "2.0.0-rc.1",
-        "@docusaurus/theme-search-algolia": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1"
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/plugin-debug": "2.0.1",
+        "@docusaurus/plugin-google-analytics": "2.0.1",
+        "@docusaurus/plugin-google-gtag": "2.0.1",
+        "@docusaurus/plugin-sitemap": "2.0.1",
+        "@docusaurus/theme-classic": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-search-algolia": "2.0.1",
+        "@docusaurus/types": "2.0.1"
       }
     },
     "@docusaurus/react-loadable": {
@@ -28919,22 +28919,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-rc.1.tgz",
-      "integrity": "sha512-qNiz7ieeq3AC+V8TbW6S63pWLJph1CbzWDDPTqxDLHgA8VQaNaSmJM8S92pH+yKALRb9u14ogjjYYc75Nj2JmQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz",
+      "integrity": "sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/module-type-aliases": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-blog": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-docs": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-pages": "2.0.0-rc.1",
-        "@docusaurus/theme-common": "2.0.0-rc.1",
-        "@docusaurus/theme-translations": "2.0.0-rc.1",
-        "@docusaurus/types": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-common": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-translations": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -28958,16 +28958,16 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-rc.1.tgz",
-      "integrity": "sha512-1r9ZLKD9SeoCYVzWzcdR79Dia4ANlrlRjNl6uzETOEybjK6FF7yEa9Yra8EJcOCbi3coyYz5xFh/r1YHFTFHug==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.1.tgz",
+      "integrity": "sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.0.0-rc.1",
-        "@docusaurus/module-type-aliases": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-blog": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-docs": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-pages": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -28986,18 +28986,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-rc.1.tgz",
-      "integrity": "sha512-H5yq6V/B4qo6GZrDKMbeSpk3T9e9K2MliDzLonRu0w3QHW9orVGe0c/lZvRbGlDZjnsOo7XGddhXXIDWGwnpaA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz",
+      "integrity": "sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.0.0-rc.1",
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/plugin-content-docs": "2.0.0-rc.1",
-        "@docusaurus/theme-common": "2.0.0-rc.1",
-        "@docusaurus/theme-translations": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
-        "@docusaurus/utils-validation": "2.0.0-rc.1",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-translations": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -29016,9 +29016,9 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.0-rc.1.tgz",
-      "integrity": "sha512-JLhNdlnbQhxVQzOnLyiCaTzKFa1lpVrM3nCrkGQKscoG2rY6ARGYMgMN2DkoH6hm7TflQ8+PE1S5MzzASeLs4Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz",
+      "integrity": "sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -29032,9 +29032,9 @@
       }
     },
     "@docusaurus/types": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-rc.1.tgz",
-      "integrity": "sha512-wX25FOZa/aKnCGA5ljWPaDpMW3TuTbs0BtjQ8WTC557p8zDvuz4r+g2/FPHsgWE0TKwUMf4usQU1m3XpJLPN+g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -29054,11 +29054,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ym9I1OwIYbKs1LGaUajaA/vDG8VweJj/6YoZjHp+eDQHhTRIrHXiYoGDqorafRhftKwnA1EnyomuXpNd9bq8Gg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz",
+      "integrity": "sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-rc.1",
+        "@docusaurus/logger": "2.0.1",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -29134,9 +29134,9 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-rc.1.tgz",
-      "integrity": "sha512-+iZICpeFPZJ9oGJXuG92WTWee6WRnVx5BdzlcfuKf/f5KQX8PvwXR2tDME78FGGhShB8zr+vjuNEXuLvXT7j2A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz",
+      "integrity": "sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==",
       "requires": {
         "tslib": "^2.4.0"
       },
@@ -29149,12 +29149,12 @@
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-rc.1.tgz",
-      "integrity": "sha512-lj36gm9Ksu4tt/EUeLDWoMbXe3sfBxeIPIUUdqYcBYkF/rpQkh+uL/dncjNGiw6uvBOqXhOfsFVP045HtgShVw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz",
+      "integrity": "sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==",
       "requires": {
-        "@docusaurus/logger": "2.0.0-rc.1",
-        "@docusaurus/utils": "2.0.0-rc.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -31530,30 +31530,30 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.1.tgz",
-      "integrity": "sha512-ZWqnbsGUgU03/IyG995pMCc+EmNVDA/4c9ntr8B0dWQwFqazOQ4ErvKZxarbgSNmyPo/eZcVsTb0bNplJMttGQ==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
+      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.14.1",
-        "@algolia/cache-common": "4.14.1",
-        "@algolia/cache-in-memory": "4.14.1",
-        "@algolia/client-account": "4.14.1",
-        "@algolia/client-analytics": "4.14.1",
-        "@algolia/client-common": "4.14.1",
-        "@algolia/client-personalization": "4.14.1",
-        "@algolia/client-search": "4.14.1",
-        "@algolia/logger-common": "4.14.1",
-        "@algolia/logger-console": "4.14.1",
-        "@algolia/requester-browser-xhr": "4.14.1",
-        "@algolia/requester-common": "4.14.1",
-        "@algolia/requester-node-http": "4.14.1",
-        "@algolia/transporter": "4.14.1"
+        "@algolia/cache-browser-local-storage": "4.14.2",
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/cache-in-memory": "4.14.2",
+        "@algolia/client-account": "4.14.2",
+        "@algolia/client-analytics": "4.14.2",
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-personalization": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/logger-console": "4.14.2",
+        "@algolia/requester-browser-xhr": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/requester-node-http": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
-      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
+      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -31916,12 +31916,12 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.4.7",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
-      "integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.8.tgz",
+      "integrity": "sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==",
       "requires": {
-        "browserslist": "^4.20.3",
-        "caniuse-lite": "^1.0.30001335",
+        "browserslist": "^4.21.3",
+        "caniuse-lite": "^1.0.30001373",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -32671,14 +32671,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
-      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "version": "4.21.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
+      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001366",
-        "electron-to-chromium": "^1.4.188",
+        "caniuse-lite": "^1.0.30001370",
+        "electron-to-chromium": "^1.4.202",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.4"
+        "update-browserslist-db": "^1.0.5"
       }
     },
     "bser": {
@@ -32846,9 +32846,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001369",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001369.tgz",
-      "integrity": "sha512-OY1SBHaodJc4wflDIKnlkdqWzJZd1Ls/2zbVJHBSv3AT7vgOJ58yAhd2CN4d57l2kPJrgMb7P9+N1Mhy4tNSQA=="
+      "version": "1.0.30001373",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ=="
     },
     "ccount": {
       "version": "1.1.0",
@@ -34823,9 +34823,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.199",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.199.tgz",
-      "integrity": "sha512-WIGME0Cs7oob3mxsJwHbeWkH0tYkIE/sjkJ8ML2BYmuRcjhRl/q5kVDXG7W9LOOKwzPU5M0LBlXRq9rlSgnNlg=="
+      "version": "1.4.210",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
+      "integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ=="
     },
     "elegant-spinner": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "rename-version": "docusaurus-rename-version",
     "format": "prettier --write '**/*.{js,json,mdx}'",
     "swizzle": "docusaurus swizzle",
+    "clear": "docusaurus clear",
     "deploy": "docusaurus deploy",
     "docusaurus": "docusaurus"
   },
@@ -44,8 +45,8 @@
     }
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-rc.1",
-    "@docusaurus/preset-classic": "^2.0.0-rc.1",
+    "@docusaurus/core": "^2.0.1",
+    "@docusaurus/preset-classic": "^2.0.1",
     "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "react": "^16.10.2",


### PR DESCRIPTION
Docusaurus is now officialy release to v2 🦖

This PR:

- updates docusaurus
- removes the [removed properties](https://docusaurus.io/docs/2.0.0-rc.1/migration/manual#removed-fields)