### PR TITLE
Add quickstart example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,5 @@
   ],
   "files.associations": {
     "*.md": "mdx"
-  },
-  "githubPullRequests.ignoredPullRequestBranches": [
-    "main"
-  ]
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
   ],
   "files.associations": {
     "*.md": "mdx"
-  }
+  },
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "main"
+  ]
 }

--- a/docs/react-testing-library/example-intro.mdx
+++ b/docs/react-testing-library/example-intro.mdx
@@ -6,7 +6,7 @@ sidebar_label: Example
 
 ## Quickstart
 
-This is a very simple setup to get you started. 
+This is a minimal setup to get you started. 
 If you want to see a description of what each line does, 
 scroll down to the [annotated version](#quickstart-annotated).
 Scroll down to [Full Example](#full-example) to see a more advanced test setup.

--- a/docs/react-testing-library/example-intro.mdx
+++ b/docs/react-testing-library/example-intro.mdx
@@ -6,26 +6,24 @@ sidebar_label: Example
 
 ## Quickstart
 
-This is a minimal setup to get you started. 
+This is a very simple setup to get you started. 
 If you want to see a description of what each line does, 
 scroll down to the [annotated version](#quickstart-annotated).
 Scroll down to [Full Example](#full-example) to see a more advanced test setup.
 
 ```jsx
-import {render, waitFor, screen} from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
-import Fetch from '../fetch'
-
-const setup = (jsx)=> ({ user: userEvent.setup(), ...render(jsx) })
+import Fetch from './fetch'
 
 test('loads and displays greeting', async () => {
 
   // ARRANGE
-  const { user } = setup(<Fetch url="/greeting" />)
+  render(<Fetch url="/greeting" />)
   
   // ACT
-  await user.click(screen.getByText('Load Greeting'))
+  await userEvent.click(screen.getByText('Load Greeting'))
   await screen.findByRole('heading')
   
   // ASSERT
@@ -40,23 +38,20 @@ test('loads and displays greeting', async () => {
 
   ```jsx
   // import react-testing methods
-  import {render, waitFor, screen} from '@testing-library/react'
+  import { render, screen } from '@testing-library/react'
+  // userEvent library simulates user interactions by dispatching the events that would happen if the interaction took place in a browser.
   import userEvent from '@testing-library/user-event'
   // add custom jest matchers from jest-dom
   import '@testing-library/jest-dom'
   // the component to test
-  import Fetch from '../fetch'
-
-  // Apply workarounds and mock the UI layer to simulate user interactions 
-  // like they would happen in the browser
-  const setup = (jsx)=> ({ user: userEvent.setup(), ...render(jsx) })
+  import Fetch from './fetch'
 
   test('loads and displays greeting', async () => {
 
-    // Run the UI setup and render a React element into the DOM
-    const { user } = setup(<Fetch url="/greeting" />)
+    // Render a React element into the DOM
+    render(<Fetch url="/greeting" />)
     
-    await user.click(screen.getByText('Load Greeting'))
+    await userEvent.click(screen.getByText('Load Greeting'))
     // wait before throwing an error if it cannot find an element
     await screen.findByRole('heading')
     

--- a/docs/react-testing-library/example-intro.mdx
+++ b/docs/react-testing-library/example-intro.mdx
@@ -6,24 +6,27 @@ sidebar_label: Example
 
 ## Quickstart
 
-This is a very simple setup to get you started. 
+This is a minimal setup to get you started. 
 If you want to see a description of what each line does, 
 scroll down to the [annotated version](#quickstart-annotated).
 Scroll down to [Full Example](#full-example) to see a more advanced test setup.
 
 ```jsx
-import {render, fireEvent, waitFor, screen} from '@testing-library/react'
+import {render, waitFor, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 import Fetch from '../fetch'
+
+const setup = (jsx)=> ({ user: userEvent.setup(), ...render(jsx) })
 
 test('loads and displays greeting', async () => {
 
   // ARRANGE
-  render(<Fetch url="/greeting" />)
+  const { user } = setup(<Fetch url="/greeting" />)
   
   // ACT
-  fireEvent.click(screen.getByText('Load Greeting'))
-  await waitFor(() => screen.getByRole('heading'))
+  await user.click(screen.getByText('Load Greeting'))
+  await screen.findByRole('heading')
   
   // ASSERT
   expect(screen.getByRole('heading')).toHaveTextContent('hello there')
@@ -37,20 +40,25 @@ test('loads and displays greeting', async () => {
 
   ```jsx
   // import react-testing methods
-  import {render, fireEvent, waitFor, screen} from '@testing-library/react'
+  import {render, waitFor, screen} from '@testing-library/react'
+  import userEvent from '@testing-library/user-event'
   // add custom jest matchers from jest-dom
   import '@testing-library/jest-dom'
   // the component to test
   import Fetch from '../fetch'
 
+  // Apply workarounds and mock the UI layer to simulate user interactions 
+  // like they would happen in the browser
+  const setup = (jsx)=> ({ user: userEvent.setup(), ...render(jsx) })
+
   test('loads and displays greeting', async () => {
 
-    // Render a React element into the DOM
-    render(<Fetch url="/greeting" />)
+    // Run the UI setup and render a React element into the DOM
+    const { user } = setup(<Fetch url="/greeting" />)
     
-    fireEvent.click(screen.getByText('Load Greeting'))
-    // getByRole throws an error if it cannot find an element
-    await waitFor(() => screen.getByRole('heading'))
+    await user.click(screen.getByText('Load Greeting'))
+    // wait before throwing an error if it cannot find an element
+    await screen.findByRole('heading')
     
     // assert that the alert message is correct using
     // toHaveTextContent, a custom matcher from jest-dom.

--- a/docs/react-testing-library/example-intro.mdx
+++ b/docs/react-testing-library/example-intro.mdx
@@ -4,6 +4,65 @@ title: Example
 sidebar_label: Example
 ---
 
+## Quickstart
+
+This is a very simple setup to get you started. 
+If you want to see a description of what each line does, 
+scroll down to the [annotated version](#quickstart-annotated).
+Scroll down to [Full Example](#full-example) to see a more advanced test setup.
+
+```jsx
+import {render, fireEvent, waitFor, screen} from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Fetch from '../fetch'
+
+test('loads and displays greeting', async () => {
+
+  // ARRANGE
+  render(<Fetch url="/greeting" />)
+  
+  // ACT
+  fireEvent.click(screen.getByText('Load Greeting'))
+  await waitFor(() => screen.getByRole('heading'))
+  
+  // ASSERT
+  expect(screen.getByRole('heading')).toHaveTextContent('hello there')
+  expect(screen.getByRole('button')).toBeDisabled()
+
+})
+```
+
+<details id="quickstart-annotated">
+  <summary>Quickstart (Annotated Example)</summary>
+
+  ```jsx
+  // import react-testing methods
+  import {render, fireEvent, waitFor, screen} from '@testing-library/react'
+  // add custom jest matchers from jest-dom
+  import '@testing-library/jest-dom'
+  // the component to test
+  import Fetch from '../fetch'
+
+  test('loads and displays greeting', async () => {
+
+    // Render a React element into the DOM
+    render(<Fetch url="/greeting" />)
+    
+    fireEvent.click(screen.getByText('Load Greeting'))
+    // getByRole throws an error if it cannot find an element
+    await waitFor(() => screen.getByRole('heading'))
+    
+    // assert that the alert message is correct using
+    // toHaveTextContent, a custom matcher from jest-dom.
+    expect(screen.getByRole('heading')).toHaveTextContent('hello there')
+    expect(screen.getByRole('button')).toBeDisabled()
+
+  })
+  ```
+
+</details>
+
+
 ## Full Example
 
 See the following sections for a detailed breakdown of the test


### PR DESCRIPTION
As an educator I've heard a lot of students complaining about the lack of a simpler setup example on the documentation.
Something like a 'Hello World' for RTL to get them started before diving into the extensive full example.

I think this quickstart example will help newcomers start with a simple setup, test it out on their project and move on from there to the more advanced concepts and probably to the Full example in this page.

