### PR TITLE
docs: reintroduce import/require usage for user-event

### DIFF
--- a/docs/user-event/install.mdx
+++ b/docs/user-event/install.mdx
@@ -26,6 +26,16 @@ yarn add --dev @testing-library/user-event
 </TabItem>
 </Tabs>
 
+Now simply import it in your tests:
+
+```js
+import userEvent from '@testing-library/user-event'
+
+// or
+
+const {default: userEvent} = require('@testing-library/user-event')
+```
+
 Note that `@testing-library/user-event` requires `@testing-library/dom`.
 
 If you use one of the


### PR DESCRIPTION
It seems like when the docs for user-event 14 were released, the docs on import/require usage were removed. However, this reintroduces issues like https://github.com/testing-library/user-event/issues/485 if you don't already know how to destructure the `default` export from the CJS module. I fixed this by copying my docs from user-event 13 (https://github.com/testing-library/user-event/pull/495).