### PR TITLE
docs: add reference to `applyAccept` from `upload()`

### DIFF
--- a/docs/user-event/api-utility.mdx
+++ b/docs/user-event/api-utility.mdx
@@ -149,6 +149,8 @@ upload(
 
 Change a file input as if a user clicked it and selected files in the resulting
 file upload dialog.
+Files that don't match an `accept` property will be automatically discarded,
+unless [`applyAccept`](options.mdx#applyaccept) is set to `false`.
 
 ```jsx
 test('upload file', async () => {


### PR DESCRIPTION
See https://github.com/testing-library/user-event/issues/1046#issuecomment-1227819119 for related discussion.