### PR TITLE
docs: add Vitest as alternative to Jest

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -12,7 +12,7 @@ there are some things you can do when configuring your testing framework to
 reduce some boilerplate. In these docs we'll demonstrate configuring Jest, but
 you should be able to do similar things with
 [any testing framework](#using-without-jest) (React Testing Library does not
-require that you use Jest).
+require that you use Jest). For example, using [React Testing Library with Vitest](https://www.robinwieruch.de/vitest-react-testing-library/) is a popular alternative to using it with Jest.
 
 ## Global Config
 


### PR DESCRIPTION
Vitest as alternative to Jest is becoming pretty popular these days. When I updated my book The Road to React, I couldn't find any guide for this setup though. So I wrote a brief guide as reference for my book and hopefully for this documentation as well.