### PR TITLE
docs: Add `renderHook` `initialProps` note when used in conjunction with `wrapper`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2177,6 +2177,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "louis-young",
+      "name": "Louis Young",
+      "avatar_url": "https://avatars.githubusercontent.com/u/35606709?v=4",
+      "profile": "https://github.com/louis-young",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -370,6 +370,22 @@ test('returns logged in user', () => {
 })
 ```
 
+> NOTE: When using `renderHook` in conjunction with the `wrapper` and `initialProps` options, the `initialProps` are not passed to the `wrapper` component. To provide dependencies to the `wrapper` component, consider a solution like this:
+>
+> ```js
+> const createWrapper = (Wrapper, props) => {
+>   return function CreatedWrapper({ children }) {
+>     return <Wrapper {...props}>{children}</Wrapper>;
+>   };
+> };
+> 
+> ...
+> 
+> {
+>   wrapper: createWrapper(Wrapper, { dependency }),
+> }
+> ```
+
 ### `renderHook` Options `wrapper`
 
 See [`wrapper` option for `render`](#wrapper)


### PR DESCRIPTION
PR for https://github.com/testing-library/testing-library-docs/issues/1161

This pull request adds a warning to the documentation about the `renderHook` `initialProps` not being passed to the `wrapper` component as they were before the React Hooks Testing library hook testing API was merged into React Testing Library.

It also adds an example solution as discussed in https://github.com/testing-library/testing-library-docs/issues/1161.

### Changes

- Add a note and example about the current behavior.
- Update contributors. 