### PR TITLE
docs: fix api docs rtl

### DIFF
--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -361,7 +361,7 @@ These will **not** be passed if you call `rerender` without props.
 import {renderHook} from '@testing-library/react'
 
 test('returns logged in user', () => {
-  const {result, rerender} = renderHook(({name} = {}) => name, {
+  const {result, rerender} = renderHook((props = {}) => props, {
     initialProps: {name: 'Alice'},
   })
   expect(result.current).toEqual({name: 'Alice'})


### PR DESCRIPTION
Error in renderHooks example, must be return the props object instead of a string