### PR TITLE
Update api-keyboard.mdx

### DIFF
--- a/docs/user-event/api-keyboard.mdx
+++ b/docs/user-event/api-keyboard.mdx
@@ -35,7 +35,7 @@ Keystrokes can be described:
   prefixing them with a backslash `\`.
 
   ```js
-  keyboard('{\}}') // translates to: }
+  keyboard('{\\}}') // translates to: }
   ```
 
 - Per


### PR DESCRIPTION
https://testing-library.com/docs/user-event/keyboard/ still does not show the \ could have it been escaped by the markdown processor?