### PR TITLE
remove FC type of functional component in example

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -78,13 +78,13 @@ export {customRender as render}
 ```
 
 ```tsx title="test-utils.tsx"
-import React, {FC, ReactElement} from 'react'
+import React, {ReactElement} from 'react'
 import {render, RenderOptions} from '@testing-library/react'
 import {ThemeProvider} from 'my-ui-lib'
 import {TranslationProvider} from 'my-i18n-lib'
 import defaultStrings from 'i18n/en-x-default'
 
-const AllTheProviders: FC<{children: React.ReactNode}> = ({children}) => {
+const AllTheProviders = ({children}:{children: React.ReactNode}) => {
   return (
     <ThemeProvider theme="light">
       <TranslationProvider messages={defaultStrings}>


### PR DESCRIPTION
Remove FC type of functional component in react typescript example since its use is discouraged as stated [here](https://github.com/facebook/create-react-app/pull/8177)