### PR TITLE
"findByRole" query over "waitFor and getByRole"

### DIFF
--- a/docs/react-testing-library/example-intro.mdx
+++ b/docs/react-testing-library/example-intro.mdx
@@ -93,7 +93,7 @@ test('loads and displays greeting', async () => {
 
   fireEvent.click(screen.getByText('Load Greeting'))
 
-  await waitFor(() => screen.getByRole('heading'))
+  await screen.findByRole('heading')
 
   expect(screen.getByRole('heading')).toHaveTextContent('hello there')
   expect(screen.getByRole('button')).toBeDisabled()


### PR DESCRIPTION
By implementing tis change, the eslint suggestion "Prefer `findByRole` query over using `waitFor` + `getByRole" is removed. The change implements the recommended suggestions by these two articles, which is the same as the automatic command line "quickfix." [1] https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/prefer-find-by.md
 [2] https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-waitfor-to-wait-for-elements-that-can-be-queried-with-find