### PR TITLE
Usage of exact option with *byRole queries

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -295,6 +295,8 @@ can contain options that affect the precision of string matching:
 - `exact`: Defaults to `true`; matches full strings, case-sensitive. When false,
   matches substrings and is not case-sensitive.
   - `exact` has no effect on `regex` or `function` arguments.
+  - `exact` has no effect on accessible names specified via `name` option of `*byRole`
+    queries. You can use regex for fuzzy matching on accessible names.
   - In most cases using a regex instead of a string gives you more control over
     fuzzy matching and should be preferred over `{ exact: false }`.
 - `normalizer`: An optional function which overrides normalization behavior. See

--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -295,8 +295,8 @@ can contain options that affect the precision of string matching:
 - `exact`: Defaults to `true`; matches full strings, case-sensitive. When false,
   matches substrings and is not case-sensitive.
   - `exact` has no effect on `regex` or `function` arguments.
-  - `exact` has no effect on accessible names specified via `name` option of `*byRole`
-    queries. You can use regex for fuzzy matching on accessible names.
+  - `exact` has no effect on accessible names specified with the `name` option of `*byRole`
+    queries. You can use a regex for fuzzy matching on accessible names.
   - In most cases using a regex instead of a string gives you more control over
     fuzzy matching and should be preferred over `{ exact: false }`.
 - `normalizer`: An optional function which overrides normalization behavior. See


### PR DESCRIPTION
Added a note about using `exact` option with *byRole queries to enable fuzzy matching. Please see details of the issue here:
https://github.com/testing-library/dom-testing-library/issues/1157
Users may expect to use `exact: false` for substring matching whereas it doesn't affect the way of filtering out DOM nodes by accessible names.