### PR TITLE
docs: fix incorrect description of getByAltText

### DIFF
--- a/docs/queries/byrole.mdx
+++ b/docs/queries/byrole.mdx
@@ -62,11 +62,10 @@ oftentimes better to use `getByRole(expectedRole, { name: 'The name' })`. The
 accessible name query does not replace other queries such as `*ByAlt` or
 `*ByTitle`. While the accessible name can be equal to these attributes, it does
 not replace the functionality of these attributes. For example
-`<img aria-label="fancy image" src="fancy.jpg" />` will be returned for both
-`getByAltText('fancy image')` and `getByRole('img', { name: 'fancy image' })`.
-However, the image will not display its description if `fancy.jpg` could not be
-loaded. Whether you want to assert this functionality in your test or not is up
-to you.
+`<img aria-label="fancy image" src="fancy.jpg" />` will be returned for
+`getByRole('img', { name: 'fancy image' })`. However, the image will not display
+its description if `fancy.jpg` could not be loaded. Whether you want to assert
+this functionality in your test or not is up to you.
 
 ## Options
 


### PR DESCRIPTION
issue: https://github.com/testing-library/testing-library-docs/issues/1190

`*ByAltText` query will not return for `<img aria-label="XXX" src="fancy.jpg" />` ([see sandbox](https://codesandbox.io/s/test-query-priority-mi4inx?file=/src/ByAltTest.test.tsx:329-436)).
