### PR TITLE
docs: Update React setup.mdx with Vitest configuration instructions

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -491,3 +491,72 @@ And register it using mocha's `-r` flag:
 ```
 mocha -r ./mocha-watch-cleanup-after-each.js
 ```
+
+## Vitest
+
+When using the react-testing-library with [Vitest](https://vitest.dev/),
+you need to install jsdom and the @testing-library:
+
+```bash npm2yarn
+npm install --save-dev jsdom
+npm install --save-dev @testing-library/react @testing-library/jest-dom
+```
+
+Since the testing library uses jsdom, you must set the `environments`
+to `jsdom`.
+
+```js
+// vite.config.js
+export default defineConfig({
+  test: {
+    // highlight-next-line
+    environment: "jsdom",
+  },
+})
+```
+
+After installing the packages and setting the environment, you can start
+testing. However, some further steps might help you develop more efficiently.
+
+When utilizing testing-library APIs, you must first import
+`@testing-library/jest-dom` in every file. It's quite inconvenient.
+It is preferable to create a file that imports testing-library.
+
+```js
+// src/setupTests.js
+import '@testing-library/jest-dom'
+```
+
+By the config `setupFiles` in vitest, you can run it before each test file.
+
+```js
+// vite.config.js
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    // highlight-next-line
+    setupFiles: "src/setupTests.js"
+  },
+})
+```
+
+Now, you don't need to import testing-library in every test file.
+
+By default, vitest does not provide [global](https://vitest.dev/config/#globals) APIs
+for explicitness, so you have to import the `describe` or `test` from vitest
+when using them. If you want to use them globally without importing them,
+you can set `globals` to `true` in the `vite.config.js`.
+
+```js
+// vite.config.js
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: "src/setupTests.js"
+    // highlight-next-line
+    globals: true,
+  },
+})
+```
+
+Now, you don't need to import the `describe` and `test` manually from vitest.

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -340,7 +340,7 @@ using Create React App without TypeScript, save this to `jsconfig.json` instead.
 
 ### Jest 28
 
-If you're using Jest 28 or later, jest-environment-jsdom package now must be installed separately. 
+If you're using Jest 28 or later, jest-environment-jsdom package now must be installed separately.
 ```bash npm2yarn
 npm install --save-dev jest-environment-jsdom
 ```
@@ -492,7 +492,7 @@ And register it using mocha's `-r` flag:
 mocha -r ./mocha-watch-cleanup-after-each.js
 ```
 
-## Vitest
+### Vitest
 
 When using the react-testing-library with [Vitest](https://vitest.dev/),
 you need to install jsdom and the @testing-library:
@@ -552,7 +552,7 @@ you can set `globals` to `true` in the `vite.config.js`.
 export default defineConfig({
   test: {
     environment: "jsdom",
-    setupFiles: "src/setupTests.js"
+    setupFiles: "src/setupTests.js",
     // highlight-next-line
     globals: true,
   },

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -542,13 +542,8 @@ export default defineConfig({
 });
 ```
 
-> **NOTE**
->
-> An alternative to JSDOM is [Happy DOM](https://github.com/capricorn86/happy-dom).
-> You can use either `jsdom` or `happy-dom` to create a browser-like environment.
-
 By default, Vitest does not provide [global](https://vitest.dev/config/#globals) APIs.
-To use them without importing them like jest,
+To use them without importing them as jest,
 you can set `globals` to `true` in the `vite.config.js`.
 
 ```js
@@ -574,45 +569,11 @@ your `tsconfig.json`.
 }
 ```
 
-> **NOTE**
->
-> Setting `test.globals` to `true` also improves compatibility when using
-> testing-library with Vitest, such as extending matchers and auto-cleanup, so
-> you don't have to set them up manually.
-
-To extends the matchers in Vitest, you just need to import the `@testing-library/jest-dom`
-after setting `test.globals` to `true`. To do this, create a `setupTests` file
-and import `@testing-library/jest-dom`.
-
-```js
-// src/setupTests.js
-import '@testing-library/jest-dom'
-```
-
-Vitest will run `src/setupTests.js` before each test file, as configured in `setupFiles`.
-
-```js
-// vite.config.js
-export default defineConfig({
-  test: {
-    environment: "jsdom",
-    globals: true,
-    // highlight-next-line
-    setupFiles: "src/setupTests.js"
-  },
-})
-```
-
-If you don't set `globals` to `true` as previously mentioned, you will need to
-extend the matchers and do the cleanup manually. You can do this in
-`setupFiles.js` as well.
+To extend the matchers and do the cleanup manually. You can do this in
+`setupFiles.js`.
 
 ```js
 // src/setupFiles.js
-
-/**
- * Do the setup here if you DO NOT set globals to true
- */
 import matchers from '@testing-library/jest-dom/matchers';
 import { cleanup } from '@testing-library/react';
 import { afterEach, expect } from 'vitest';
@@ -624,4 +585,18 @@ expect.extend(matchers);
 afterEach(() => {
   cleanup();
 });
+```
+
+Then set the `setupFiles` to `src/setupFiles.js` in the `vite.config.js`.
+
+```js
+// vite.config.js
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    // highlight-next-line
+    setupFiles: "src/setupTests.js"
+  },
+})
 ```

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -522,6 +522,25 @@ export default defineConfig({
 After installing the packages and setting the environment, you can start
 testing. However, some further steps might help you develop more efficiently.
 
+By default, vitest does not provide [global](https://vitest.dev/config/#globals) APIs
+for explicitness, so you have to import the `describe` or `test` from vitest
+when using them. If you want to use them globally without importing them,
+you can set `globals` to `true` in the `vite.config.js`.
+
+```js
+// vite.config.js
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: "src/setupTests.js",
+    // highlight-next-line
+    globals: true,
+  },
+})
+```
+
+Now, you don't need to import the `describe` and `test` manually from vitest.
+
 When utilizing testing-library APIs, you must first import
 `@testing-library/jest-dom` in every file. It's quite inconvenient.
 It is preferable to create a file that imports testing-library.
@@ -545,22 +564,3 @@ export default defineConfig({
 ```
 
 Now, you don't need to import testing-library in every test file.
-
-By default, vitest does not provide [global](https://vitest.dev/config/#globals) APIs
-for explicitness, so you have to import the `describe` or `test` from vitest
-when using them. If you want to use them globally without importing them,
-you can set `globals` to `true` in the `vite.config.js`.
-
-```js
-// vite.config.js
-export default defineConfig({
-  test: {
-    environment: "jsdom",
-    setupFiles: "src/setupTests.js",
-    // highlight-next-line
-    globals: true,
-  },
-})
-```
-
-Now, you don't need to import the `describe` and `test` manually from vitest.

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -495,14 +495,26 @@ mocha -r ./mocha-watch-cleanup-after-each.js
 ### Vitest
 
 To test web applications with [Vitest](https://vitest.dev/),
-you need to install a browser-like environemnt such as `jsdom`.
+you need to install a browser-like environment such as `jsdom`.
 
 ```bash npm2yarn
 npm install --save-dev vitest jsdom
 npm install --save-dev @testing-library/react @testing-library/jest-dom
 ```
 
-Then set the `environment` to `jsdom`.
+In the `package.json`, you can setup the script for running the test by Vitest.
+
+```json
+// package.json
+{
+  "scripts": {
+    "test": "vitest",
+    "coverage": "vitest run --coverage"
+  }
+}
+```
+
+Then set the `environment` to `jsdom` in the `vite.config.js`.
 
 ```js
 // vite.config.js
@@ -514,17 +526,29 @@ export default defineConfig({
 })
 ```
 
+If you are using TypeScript, add a triple slash command at the top of the
+config file to reference Vitest types.
+
+```ts
+// vite.config.ts
+// highlight-next-line
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});
+```
+
 > **NOTE**
 >
-> There is an altertive to JSDOM called [Happy DOM](https://github.com/capricorn86/happy-dom).
-> You can use browser-like environemnt through either `jsdom` or `happy-dom`.
+> An alternative to JSDOM is [Happy DOM](https://github.com/capricorn86/happy-dom).
+> You can use either `jsdom` or `happy-dom` to create a browser-like environment.
 
-After installing the packages and setting the environment, you can start
-testing. However, some further steps might help you develop more efficiently.
-
-By default, vitest does not provide [global](https://vitest.dev/config/#globals) APIs
-for explicitness, so you have to import the `describe` or `test` from vitest
-when using them. If you want to use them globally without importing them,
+By default, Vitest does not provide [global](https://vitest.dev/config/#globals) APIs.
+To use them without importing them like jest,
 you can set `globals` to `true` in the `vite.config.js`.
 
 ```js
@@ -532,35 +556,49 @@ you can set `globals` to `true` in the `vite.config.js`.
 export default defineConfig({
   test: {
     environment: "jsdom",
-    setupFiles: "src/setupTests.js",
     // highlight-next-line
     globals: true,
   },
 })
 ```
 
-Now, you don't need to import the `describe` and `test` manually from vitest.
+If you are using TypeScript, you need to add `vitest/global` to the `types` field in
+your `tsconfig.json`.
 
-When utilizing testing-library APIs, you must first import
-`@testing-library/jest-dom` in every file. It's quite inconvenient.
-It is preferable to create a file that imports testing-library.
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}
+```
+
+> **NOTE**
+>
+> Setting `test.globals` to `true` also improves compatibility when using
+> testing-library with Vitest, such as extending matchers and auto-cleanup, so
+> you don't have to set them up manually.
+
+To extends the matchers in Vitest, you just need to import the `@testing-library/jest-dom`
+after setting `test.globals` to `true`. To do this, create a `setupTests` file
+and import `@testing-library/jest-dom`.
 
 ```js
 // src/setupTests.js
 import '@testing-library/jest-dom'
 ```
 
-By the config `setupFiles` in vitest, you can run it before each test file.
+Vitest will run `src/setupTests.js` before each test file, as configured in `setupFiles`.
 
 ```js
 // vite.config.js
 export default defineConfig({
   test: {
     environment: "jsdom",
+    globals: true,
     // highlight-next-line
     setupFiles: "src/setupTests.js"
   },
 })
 ```
-
-Now, you don't need to import testing-library in every test file.

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -602,3 +602,26 @@ export default defineConfig({
   },
 })
 ```
+
+If you don't set `globals` to `true` as previously mentioned, you will need to
+extend the matchers and do the cleanup manually. You can do this in
+`setupFiles.js` as well.
+
+```js
+// src/setupFiles.js
+
+/**
+ * Do the setup here if you DO NOT set globals to true
+ */
+import matchers from '@testing-library/jest-dom/matchers';
+import { cleanup } from '@testing-library/react';
+import { afterEach, expect } from 'vitest';
+
+// Extends Vitest's expect function with matchers from the testing-library
+expect.extend(matchers);
+
+// Unmounts React trees that were mounted with render.
+afterEach(() => {
+  cleanup();
+});
+```

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -498,7 +498,7 @@ When using the react-testing-library with [Vitest](https://vitest.dev/),
 you need to install jsdom and the @testing-library:
 
 ```bash npm2yarn
-npm install --save-dev jsdom
+npm install --save-dev vitest jsdom
 npm install --save-dev @testing-library/react @testing-library/jest-dom
 ```
 

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -494,16 +494,15 @@ mocha -r ./mocha-watch-cleanup-after-each.js
 
 ### Vitest
 
-When using the react-testing-library with [Vitest](https://vitest.dev/),
-you need to install jsdom and the @testing-library:
+To test web applications with [Vitest](https://vitest.dev/),
+you need to install a browser-like environemnt such as `jsdom`.
 
 ```bash npm2yarn
 npm install --save-dev vitest jsdom
 npm install --save-dev @testing-library/react @testing-library/jest-dom
 ```
 
-Since the testing library uses jsdom, you must set the `environments`
-to `jsdom`.
+Then set the `environment` to `jsdom`.
 
 ```js
 // vite.config.js
@@ -514,6 +513,11 @@ export default defineConfig({
   },
 })
 ```
+
+> **NOTE**
+>
+> There is an altertive to JSDOM called [Happy DOM](https://github.com/capricorn86/happy-dom).
+> You can use browser-like environemnt through either `jsdom` or `happy-dom`.
 
 After installing the packages and setting the environment, you can start
 testing. However, some further steps might help you develop more efficiently.


### PR DESCRIPTION
Vitest is becoming a popular tool for starting a React project from scratch. However, there is still no documentation on how to use it. I felt it would be useful to update the React developer documentation with Vitest instructions.

Please let me know if the section needs to be reorganized or if further information is required.