### PR TITLE
docs: Fix example input event code errors

### DIFF
--- a/docs/example-input-event.mdx
+++ b/docs/example-input-event.mdx
@@ -16,10 +16,10 @@ import {render, fireEvent} from '@testing-library/react'
 function CostInput() {
   const [value, setValue] = useState('')
 
-  removeDollarSign = value => (value[0] === '$' ? value.slice(1) : value)
-  getReturnValue = value => (value === '' ? '' : `$${value}`)
+  const removeDollarSign = value => (value[0] === '$' ? value.slice(1) : value)
+  const getReturnValue = value => (value === '' ? '' : `$${value}`)
 
-  handleChange = ev => {
+  const handleChange = ev => {
     ev.preventDefault()
     const inputtedValue = ev.currentTarget.value
     const noDollarSign = removeDollarSign(inputtedValue)

--- a/docs/example-input-event.mdx
+++ b/docs/example-input-event.mdx
@@ -11,7 +11,7 @@ sidebar_label: Input Event
 
 ```jsx
 import React, {useState} from 'react'
-import {render, fireEvent} from '@testing-library/react'
+import {screen, render, fireEvent} from '@testing-library/react'
 
 function CostInput() {
   const [value, setValue] = useState('')
@@ -32,7 +32,7 @@ function CostInput() {
 
 const setup = () => {
   const utils = render(<CostInput />)
-  const input = utils.getByLabelText('cost-input')
+  const input = screen.getByLabelText('cost-input')
   return {
     input,
     ...utils,


### PR DESCRIPTION
1. 3 instances of `const` were missing from function declarations - these have been added
2. The `getByLabelText` on line 35 was underlined in red saying
to use `screen` instead of `utils`

Resolves #1222