### PR TITLE
Update link to "What is an accessible name" guide

### DIFF
--- a/docs/queries/byrole.mdx
+++ b/docs/queries/byrole.mdx
@@ -55,7 +55,7 @@ accessible name is for simple cases equal to e.g. the label of a form element,
 or the text content of a button, or the value of the `aria-label` attribute. It
 can be used to query a specific element if multiple elements with the same role
 are present on the rendered content. For an in-depth guide check out
-["What is an accessible name?" from ThePacielloGroup](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/).
+["What is an accessible name?" from TPGi](https://www.tpgi.com/what-is-an-accessible-name/).
 If you only query for a single element with `getByText('The name')` it's
 oftentimes better to use `getByRole(expectedRole, { name: 'The name' })`. The
 accessible name query does not replace other queries such as `*ByAlt` or


### PR DESCRIPTION
The Paciello Group is now called TPGi https://www.tpgi.com/the-paciello-group-is-now-tpgi/ and the previous link is now redirected to the home page of TPGi.

Could not find a PR template, please let me know if there is one around.