### PR TITLE
docs(vue): remove extra callbackFunction parameter

### DIFF
--- a/docs/vue-testing-library/api.mdx
+++ b/docs/vue-testing-library/api.mdx
@@ -35,7 +35,7 @@ Library.
 It takes up to 2 parameters and returns an object with some helper methods.
 
 ```js
-function render(Component, options, callbackFunction) {
+function render(Component, options) {
   return {
     ...DOMTestingLibraryQueries,
     container,


### PR DESCRIPTION
Teeny tiny cleanup from the overhaul done in #1141.

This callback used to provide a way to install additional plugins, but now that's handled by [the `global.plugins` array from `@vue/test-utils` mount options.](https://test-utils.vuejs.org/api/#global)