### PR TITLE
fix(byLabelText): wording about the selector

### DIFF
--- a/docs/queries/bylabeltext.mdx
+++ b/docs/queries/bylabeltext.mdx
@@ -94,7 +94,7 @@ is robust against switching to `aria-label` or `aria-labelledby`.
 
 ### `selector`
 
-If it is important that you query an actual `<label>` element you can provide a
+If it is important that you query a specific element (e.g. an `<input>`) you can provide a
 `selector` in the options:
 
 ```js


### PR DESCRIPTION
The sentence talks about selecting a `<label>` but the example is selecting a `<input>`. This PR fixes the sentence.