### PR TITLE
Move explanation about findBy combination to Single Elements

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -59,6 +59,10 @@ test('should show login form', () => {
     matches the given query. The promise is rejected if no element is found or
     if more than one element is found after a default timeout of 1000ms. If you
     need to find more than one element, use `findAllBy`.
+    - `findBy` methods are a combination of `getBy*` queries and
+      [`waitFor`](../dom-testing-library/api-async.mdx#waitfor). They accept the
+      `waitFor` options as the last argument (i.e.
+      `await screen.findByText('text', queryOptions, waitForOptions)`).
 - Multiple Elements
   - `getAllBy...`: Returns an array of all matching nodes for a query, and
     throws an error if no elements match.
@@ -67,10 +71,6 @@ test('should show login form', () => {
   - `findAllBy...`: Returns a promise which resolves to an array of elements
     when any elements are found which match the given query. The promise is
     rejected if no elements are found after a default timeout of `1000`ms.
-    - `findBy` methods are a combination of `getBy*` queries and
-      [`waitFor`](../dom-testing-library/api-async.mdx#waitfor). They accept the
-      `waitFor` options as the last argument (i.e.
-      `await screen.findByText('text', queryOptions, waitForOptions)`)
 
 <details open>
 
@@ -295,8 +295,9 @@ can contain options that affect the precision of string matching:
 - `exact`: Defaults to `true`; matches full strings, case-sensitive. When false,
   matches substrings and is not case-sensitive.
   - `exact` has no effect on `regex` or `function` arguments.
-  - `exact` has no effect on accessible names specified with the `name` option of `*byRole`
-    queries. You can use a regex for fuzzy matching on accessible names.
+  - `exact` has no effect on accessible names specified with the `name` option
+    of `*byRole` queries. You can use a regex for fuzzy matching on accessible
+    names.
   - In most cases using a regex instead of a string gives you more control over
     fuzzy matching and should be preferred over `{ exact: false }`.
 - `normalizer`: An optional function which overrides normalization behavior. See
@@ -375,8 +376,8 @@ screen.debug(screen.getAllByText('multi-test'))
 ### `screen.logTestingPlaygroundURL()`
 
 For debugging using [testing-playground](https://testing-playground.com), screen
-exposes this convenient method which logs and returns a URL that can be opened in
-a browser.
+exposes this convenient method which logs and returns a URL that can be opened
+in a browser.
 
 ```javascript
 import {screen} from '@testing-library/dom'


### PR DESCRIPTION
The explanation about `findBy` combination is more related to `Single Elements` instead of `Multiple Elements`, so move it upwards.