### PR TITLE
Add imports to `user-event` intro documentation

### DIFF
--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -59,6 +59,8 @@ itself - e.g. in a `before`/`after` hook - for reasons described in
 ["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing).
 
 ```js
+import userEvent from '@testing-library/user-event'
+
 // inlining
 test('trigger some awesome feature when clicking the button', async () => {
   const user = userEvent.setup()
@@ -71,6 +73,8 @@ test('trigger some awesome feature when clicking the button', async () => {
 ```
 
 ```js
+import userEvent from '@testing-library/user-event'
+
 // setup function
 function setup(jsx) {
   return {

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -61,6 +61,7 @@ itself - e.g. in a `before`/`after` hook - for reasons described in
 ```js
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
+import MyComponent from './MyComponent.vue'
 
 // inlining
 test('trigger some awesome feature when clicking the button', async () => {
@@ -76,6 +77,7 @@ test('trigger some awesome feature when clicking the button', async () => {
 ```js
 import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
+import MyComponent from './MyComponent.vue'
 
 // setup function
 function setup(jsx) {

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -64,7 +64,7 @@ import userEvent from '@testing-library/user-event'
 // inlining
 test('trigger some awesome feature when clicking the button', async () => {
   const user = userEvent.setup()
-  // Import `render` from the framework library of your choice.
+  // Import `render` and `screen` from the framework library of your choice.
   // See https://testing-library.com/docs/dom-testing-library/install#wrappers
   render(<MyComponent />)
 
@@ -88,8 +88,6 @@ function setup(jsx) {
 }
 
 test('render with a setup function', async () => {
-  // Import `setup` from the framework library of your choice.
-  // See https://testing-library.com/docs/dom-testing-library/install#wrappers
   const { user } = setup(<MyComponent />)
   // ...
 })

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -61,7 +61,6 @@ itself - e.g. in a `before`/`after` hook - for reasons described in
 ```js
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import MyComponent from './MyComponent.vue'
 
 // inlining
 test('trigger some awesome feature when clicking the button', async () => {
@@ -77,7 +76,6 @@ test('trigger some awesome feature when clicking the button', async () => {
 ```js
 import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
-import MyComponent from './MyComponent.vue'
 
 // setup function
 function setup(jsx) {

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -60,14 +60,15 @@ itself - e.g. in a `before`/`after` hook - for reasons described in
 
 ```js
 import userEvent from '@testing-library/user-event'
-import { render, screen } from '@testing-library/vue'
 
 // inlining
 test('trigger some awesome feature when clicking the button', async () => {
   const user = userEvent.setup()
+  // Import `render` from the framework library of your choice.
+  // See https://testing-library.com/docs/dom-testing-library/install#wrappers
   render(<MyComponent />)
 
-  await user.click(screen.getByRole('button', {name: /click me!/i}))
+  await user.click(screen.getByRole('button', { name: /click me!/i }))
 
   // ...assertions...
 })
@@ -75,18 +76,21 @@ test('trigger some awesome feature when clicking the button', async () => {
 
 ```js
 import userEvent from '@testing-library/user-event'
-import { render } from '@testing-library/vue'
 
 // setup function
 function setup(jsx) {
   return {
     user: userEvent.setup(),
+    // Import `render` from the framework library of your choice.
+    // See https://testing-library.com/docs/dom-testing-library/install#wrappers
     ...render(jsx),
   }
 }
 
 test('render with a setup function', async () => {
-  const {user} = setup(<MyComponent />)
+  // Import `setup` from the framework library of your choice.
+  // See https://testing-library.com/docs/dom-testing-library/install#wrappers
+  const { user } = setup(<MyComponent />)
   // ...
 })
 ```

--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -60,6 +60,7 @@ itself - e.g. in a `before`/`after` hook - for reasons described in
 
 ```js
 import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
 
 // inlining
 test('trigger some awesome feature when clicking the button', async () => {
@@ -74,6 +75,7 @@ test('trigger some awesome feature when clicking the button', async () => {
 
 ```js
 import userEvent from '@testing-library/user-event'
+import { render } from '@testing-library/vue'
 
 // setup function
 function setup(jsx) {


### PR DESCRIPTION
It took me a while to understand how to import `userEvent` and even to understand that it was a separate library. 😶‍🌫️ 

I think adding these imports would make it clearer for users that get into the page and quickly scroll for the code examples.