### PR TITLE
docs(user-event): add missing default value for `skipHover`

### DIFF
--- a/docs/user-event/options.mdx
+++ b/docs/user-event/options.mdx
@@ -120,6 +120,8 @@ This option allows to opt out of this feature.
 element first.  
 This option allows to opt out of this feature.
 
+`default`: false
+
 ### writeToClipboard
 
 Write selected data to


### PR DESCRIPTION
The value is already `false` in the source code. This change just specify it in the doc.
* respective file: https://github.com/testing-library/user-event/blob/7a305dee9ab833d6f338d567fc2e862b4838b76a/src/setup/setup.ts#LL31C3-L31C12