### PR TITLE
docs: update examples to remove a deleted example

### DIFF
--- a/docs/vue-testing-library/examples.mdx
+++ b/docs/vue-testing-library/examples.mdx
@@ -103,4 +103,3 @@ Some included are:
 - [`vue-router`](https://github.com/testing-library/vue-testing-library/tree/main/src/__tests__/vue-router.js)
 - [`vue-validate`](https://github.com/testing-library/vue-testing-library/tree/main/src/__tests__/validate-plugin.js)
 - [`vue-i18n`](https://github.com/testing-library/vue-testing-library/blob/main/src/__tests__/translations-vue-i18n.js)
-- [`vuetify`](https://github.com/testing-library/vue-testing-library/blob/main/src/__tests__/vuetify.js)


### PR DESCRIPTION
File was [deleted here](https://github.com/testing-library/vue-testing-library/pull/303/files#diff-f06baa1c59c6f049eebdb2bebe06ae4455a8440ef9b260ac45bec473d2959203).