### PR TITLE
docs: added alt text to img to fix a11y issue

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -348,6 +348,7 @@ module.exports = {
       copyright: `Copyright © 2018-${new Date().getFullYear()} Kent C. Dodds and contributors`,
       logo: {
         src: 'img/octopus-128x128.png',
+        alt: 'An octopus representing the DOM Testing Library Logo'
       },
     },
     algolia: {


### PR DESCRIPTION
## Description of Change
- Updated docs to add alt text to img to fix critical accessibility issue as seen with axe devTools chrome extension

## Screenshots

**Before Change:**

<img width="1920" alt="Before Change -- Axe Tool" src="https://github.com/testing-library/testing-library-docs/assets/34246811/9d6e45a9-9534-4f26-8a92-e1f08e9a4e7e">

**After Change:** 

<img width="1920" alt="After Change -- Axe Tool" src="https://github.com/testing-library/testing-library-docs/assets/34246811/cd5693f7-cea3-492d-8855-f5a6cc6a32b4">

