### PR TITLE
docs: userEvent/convenience Example Code

### DIFF
--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -182,13 +182,15 @@ keyboard('[/ShiftLeft][/ShiftRight]{Tab}')
 test('tab', async () => {
   render(
     <div>
-      <input data-testid="element" type="checkbox" />
-      <input data-testid="element" type="radio" />
-      <input data-testid="element" type="number" />
+      <input type="checkbox" />
+      <input type="radio" />
+      <input type="number" />
     </div>,
   )
 
-  const [checkbox, radio, number] = screen.getAllByTestId('element')
+  const checkbox = screen.getByRole('checkbox')
+  const radio = screen.getByRole('radio')
+  const number = screen.getByRole('spinbutton')
 
   expect(document.body).toHaveFocus()
 

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -100,6 +100,7 @@ pointer({target: element})
 ```js
 const TestComponent = () => {
   const [isHover, setIsHover] = useState(false)
+
   return (
     <div
       style={{backgroundColor: isHover ? 'red' : 'green'}}
@@ -111,42 +112,7 @@ const TestComponent = () => {
   )
 }
 
-test('hover', async () => {
-  render(<TestComponent />)
-
-  const hoverBox = screen.getByText('Hover')
-
-  await userEvent.hover(hoverBox)
-
-  expect(hoverBox).toHaveStyle({backgroundColor: 'red'})
-})
-```
-
-### unhover()
-
-```ts
-unhover(element: Element): Promise<void>
-```
-
-```js
-pointer({target: element.ownerDocument.body})
-```
-
-```js
-const TestComponent = () => {
-  const [isHover, setIsHover] = useState(false)
-  return (
-    <div
-      style={{backgroundColor: isHover ? 'red' : 'green'}}
-      onMouseEnter={() => setIsHover(true)}
-      onMouseLeave={() => setIsHover(false)}
-    >
-      Hover
-    </div>
-  )
-}
-
-test('unhover', async () => {
+test('hover/unhover', async () => {
   render(<TestComponent />)
 
   const hoverBox = screen.getByText('Hover')
@@ -159,6 +125,16 @@ test('unhover', async () => {
 
   expect(hoverBox).toHaveStyle({backgroundColor: 'green'})
 })
+```
+
+### unhover()
+
+```ts
+unhover(element: Element): Promise<void>
+```
+
+```js
+pointer({target: element.ownerDocument.body})
 ```
 
 ## Keyboard

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -20,13 +20,16 @@ pointer([{target: element}, {keys: '[MouseLeft]', target: element}])
 
 ```js
 test('click', async () => {
+  const onChange = jest.fn()
   const user = userEvent.setup()
-  render(<input type="checkbox" />)
+
+  render(<input type="checkbox" onChange={onChange} />)
 
   const checkbox = screen.getByRole('checkbox')
 
   await user.click(checkbox)
 
+  expect(onChange).toHaveBeenCalledTimes(1)
   expect(checkbox).toBeChecked()
 })
 ```
@@ -45,13 +48,16 @@ pointer([{target: element}, {keys: '[MouseLeft][MouseLeft]', target: element}])
 
 ```js
 test('double click', async () => {
+  const onChange = jest.fn()
   const user = userEvent.setup()
-  render(<input type="checkbox" />)
+
+  render(<input type="checkbox" onChange={onChange} />)
 
   const checkbox = screen.getByRole('checkbox')
 
   await user.dblClick(checkbox)
 
+  expect(onChange).toHaveBeenCalledTimes(2)
   expect(checkbox).not.toBeChecked()
 })
 ```
@@ -71,13 +77,16 @@ pointer([
 
 ```js
 test('triple click', async () => {
+  const onChange = jest.fn()
   const user = userEvent.setup()
-  render(<input type="checkbox" />)
+
+  render(<input type="checkbox" onChange={onChange} />)
 
   const checkbox = screen.getByRole('checkbox')
 
   await user.tripleClick(checkbox)
 
+  expect(onChange).toHaveBeenCalledTimes(3)
   expect(checkbox).toBeChecked()
 })
 ```
@@ -95,33 +104,29 @@ pointer({target: element})
 ```
 
 ```js
-const TestComponent = () => {
-  const [isHover, setIsHover] = useState(false)
-
-  return (
-    <p
-      role="paragraph"
-      onMouseEnter={() => setIsHover(true)}
-      onMouseLeave={() => setIsHover(false)}
-    >
-      {isHover ? 'Hover' : 'UnHover'}
-    </p>
-  )
-}
-
 test('hover/unhover', async () => {
   const user = userEvent.setup()
-  render(<TestComponent />)
+  render(<div>Hover</div>)
 
-  const paragraph = screen.getByRole('paragraph')
+  const hoverBox = screen.getByText('Hover')
+  let isHover = false
 
-  await user.hover(paragraph)
+  hoverBox.addEventListener('mouseover', () => {
+    isHover = true
+  })
+  hoverBox.addEventListener('mouseout', () => {
+    isHover = false
+  })
 
-  expect(paragraph).toHaveTextContent('Hover')
+  expect(isHover).toBeFalsy()
 
-  await user.unhover(paragraph)
+  await user.hover(hoverBox)
 
-  expect(paragraph).toHaveTextContent('UnHover')
+  expect(isHover).toBeTruthy()
+
+  await user.unhover(hoverBox)
+
+  expect(isHover).toBeFalsy()
 })
 ```
 

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -21,7 +21,7 @@ pointer([{target: element}, {keys: '[MouseLeft]', target: element}])
 ```js
 test('click', async () => {
   const user = userEvent.setup()
-  render(<input type="checkbox" onChange={onChange} />)
+  render(<input type="checkbox" />)
 
   const checkbox = screen.getByRole('checkbox')
 
@@ -46,7 +46,7 @@ pointer([{target: element}, {keys: '[MouseLeft][MouseLeft]', target: element}])
 ```js
 test('double click', async () => {
   const user = userEvent.setup()
-  render(<input type="checkbox" onChange={onChange} />)
+  render(<input type="checkbox" />)
 
   const checkbox = screen.getByRole('checkbox')
 
@@ -72,7 +72,7 @@ pointer([
 ```js
 test('triple click', async () => {
   const user = userEvent.setup()
-  render(<input type="checkbox" onChange={onChange} />)
+  render(<input type="checkbox" />)
 
   const checkbox = screen.getByRole('checkbox')
 
@@ -97,15 +97,15 @@ pointer({target: element})
 ```js
 const TestComponent = () => {
   const [isHover, setIsHover] = useState(false)
-  
+
   return (
-    <div
-      style={{ backgroundColor: isHover ? 'red' : 'green' }}
+    <p
+      role="paragraph"
       onMouseEnter={() => setIsHover(true)}
       onMouseLeave={() => setIsHover(false)}
     >
-      Hover
-    </div>
+      {isHover ? 'Hover' : 'UnHover'}
+    </p>
   )
 }
 
@@ -113,15 +113,15 @@ test('hover/unhover', async () => {
   const user = userEvent.setup()
   render(<TestComponent />)
 
-  const hoverBox = screen.getByText('Hover')
+  const paragraph = screen.getByRole('paragraph')
 
-  await userEvent.hover(hoverBox)
+  await user.hover(paragraph)
 
-  expect(hoverBox).toHaveStyle({ backgroundColor: 'red' })
+  expect(paragraph).toHaveTextContent('Hover')
 
-  await userEvent.unhover(hoverBox)
+  await user.unhover(paragraph)
 
-  expect(hoverBox).toHaveStyle({ backgroundColor: 'green' })
+  expect(paragraph).toHaveTextContent('UnHover')
 })
 ```
 

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -21,14 +21,12 @@ pointer([{target: element}, {keys: '[MouseLeft]', target: element}])
 ```js
 test('click', async () => {
   const user = userEvent.setup()
-  const onChange = jest.fn()
   render(<input type="checkbox" onChange={onChange} />)
 
   const checkbox = screen.getByRole('checkbox')
 
   await user.click(checkbox)
 
-  expect(onChange).toHaveBeenCalledTimes(1)
   expect(checkbox).toBeChecked()
 })
 ```
@@ -48,14 +46,12 @@ pointer([{target: element}, {keys: '[MouseLeft][MouseLeft]', target: element}])
 ```js
 test('double click', async () => {
   const user = userEvent.setup()
-  const onChange = jest.fn()
   render(<input type="checkbox" onChange={onChange} />)
 
   const checkbox = screen.getByRole('checkbox')
 
   await user.dblClick(checkbox)
 
-  expect(onChange).toHaveBeenCalledTimes(2)
   expect(checkbox).not.toBeChecked()
 })
 ```
@@ -76,14 +72,12 @@ pointer([
 ```js
 test('triple click', async () => {
   const user = userEvent.setup()
-  const onChange = jest.fn()
   render(<input type="checkbox" onChange={onChange} />)
 
   const checkbox = screen.getByRole('checkbox')
 
   await user.tripleClick(checkbox)
 
-  expect(onChange).toHaveBeenCalledTimes(3)
   expect(checkbox).toBeChecked()
 })
 ```

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -20,12 +20,13 @@ pointer([{target: element}, {keys: '[MouseLeft]', target: element}])
 
 ```js
 test('click', async () => {
+  const user = userEvent.setup()
   const onChange = jest.fn()
   render(<input type="checkbox" onChange={onChange} />)
 
   const checkbox = screen.getByRole('checkbox')
 
-  await userEvent.click(checkbox)
+  await user.click(checkbox)
 
   expect(onChange).toHaveBeenCalledTimes(1)
   expect(checkbox).toBeChecked()
@@ -46,12 +47,13 @@ pointer([{target: element}, {keys: '[MouseLeft][MouseLeft]', target: element}])
 
 ```js
 test('double click', async () => {
+  const user = userEvent.setup()
   const onChange = jest.fn()
   render(<input type="checkbox" onChange={onChange} />)
 
   const checkbox = screen.getByRole('checkbox')
 
-  await userEvent.dblClick(checkbox)
+  await user.dblClick(checkbox)
 
   expect(onChange).toHaveBeenCalledTimes(2)
   expect(checkbox).not.toBeChecked()
@@ -73,12 +75,13 @@ pointer([
 
 ```js
 test('triple click', async () => {
+  const user = userEvent.setup()
   const onChange = jest.fn()
   render(<input type="checkbox" onChange={onChange} />)
 
   const checkbox = screen.getByRole('checkbox')
 
-  await userEvent.tripleClick(checkbox)
+  await user.tripleClick(checkbox)
 
   expect(onChange).toHaveBeenCalledTimes(3)
   expect(checkbox).toBeChecked()
@@ -102,28 +105,29 @@ const TestComponent = () => {
   const [isHover, setIsHover] = useState(false)
 
   return (
-    <div
-      style={{backgroundColor: isHover ? 'red' : 'green'}}
+    <p
+      role="paragraph"
       onMouseEnter={() => setIsHover(true)}
       onMouseLeave={() => setIsHover(false)}
     >
-      Hover
-    </div>
+      {isHover ? 'Hover' : 'UnHover'}
+    </p>
   )
 }
 
 test('hover/unhover', async () => {
+  const user = userEvent.setup()
   render(<TestComponent />)
 
-  const hoverBox = screen.getByText('Hover')
+  const paragraph = screen.getByRole('paragraph')
 
-  await userEvent.hover(hoverBox)
+  await user.hover(paragraph)
 
-  expect(hoverBox).toHaveStyle({backgroundColor: 'red'})
+  expect(paragraph).toHaveTextContent('Hover')
 
-  await userEvent.unhover(hoverBox)
+  await user.unhover(paragraph)
 
-  expect(hoverBox).toHaveStyle({backgroundColor: 'green'})
+  expect(paragraph).toHaveTextContent('UnHover')
 })
 ```
 
@@ -156,6 +160,7 @@ keyboard('[/ShiftLeft][/ShiftRight]{Tab}')
 
 ```js
 test('tab', async () => {
+  const user = userEvent.setup()
   render(
     <div>
       <input type="checkbox" />
@@ -170,24 +175,24 @@ test('tab', async () => {
 
   expect(document.body).toHaveFocus()
 
-  await userEvent.tab()
+  await user.tab()
 
   expect(checkbox).toHaveFocus()
 
-  await userEvent.tab()
+  await user.tab()
 
   expect(radio).toHaveFocus()
 
-  await userEvent.tab()
+  await user.tab()
 
   expect(number).toHaveFocus()
 
-  await userEvent.tab()
+  await user.tab()
 
   // cycle goes back to the body element
   expect(document.body).toHaveFocus()
 
-  await userEvent.tab()
+  await user.tab()
 
   expect(checkbox).toHaveFocus()
 })

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -97,15 +97,15 @@ pointer({target: element})
 ```js
 const TestComponent = () => {
   const [isHover, setIsHover] = useState(false)
-
+  
   return (
-    <p
-      role="paragraph"
+    <div
+      style={{ backgroundColor: isHover ? 'red' : 'green' }}
       onMouseEnter={() => setIsHover(true)}
       onMouseLeave={() => setIsHover(false)}
     >
-      {isHover ? 'Hover' : 'UnHover'}
-    </p>
+      Hover
+    </div>
   )
 }
 
@@ -113,15 +113,15 @@ test('hover/unhover', async () => {
   const user = userEvent.setup()
   render(<TestComponent />)
 
-  const paragraph = screen.getByRole('paragraph')
+  const hoverBox = screen.getByText('Hover')
 
-  await user.hover(paragraph)
+  await userEvent.hover(hoverBox)
 
-  expect(paragraph).toHaveTextContent('Hover')
+  expect(hoverBox).toHaveStyle({ backgroundColor: 'red' })
 
-  await user.unhover(paragraph)
+  await userEvent.unhover(hoverBox)
 
-  expect(paragraph).toHaveTextContent('UnHover')
+  expect(hoverBox).toHaveStyle({ backgroundColor: 'green' })
 })
 ```
 

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -18,6 +18,20 @@ click(element: Element): Promise<void>
 pointer([{target: element}, {keys: '[MouseLeft]', target: element}])
 ```
 
+```js
+test("click", async () => {
+  render(
+    <div>
+      <label htmlFor="checkbox">Check</label>
+      <input id="checkbox" type="checkbox" />
+    </div>
+  );
+
+  await userEvent.click(screen.getByText("Check"));
+  expect(screen.getByLabelText("Check")).toBeChecked();
+});
+```
+
 The first action might be skipped per [`skipHover`](options.mdx#skiphover).
 
 ### dblClick()
@@ -28,6 +42,20 @@ dblClick(element: Element): Promise<void>
 
 ```js
 pointer([{target: element}, {keys: '[MouseLeft][MouseLeft]', target: element}])
+```
+
+```js
+test("double click", async () => {
+  const onChange = jest.fn();
+  render(<input type="checkbox" onChange={onChange} />);
+
+  const checkbox = screen.getByRole("checkbox");
+
+  await userEvent.dblClick(checkbox);
+
+  expect(onChange).toHaveBeenCalledTimes(2);
+  expect(checkbox).not.toBeChecked();
+});
 ```
 
 ### tripleClick()
@@ -43,6 +71,20 @@ pointer([
 ])
 ```
 
+```js
+test("triple click", async () => {
+  const onChange = jest.fn();
+  render(<input type="checkbox" onChange={onChange} />);
+
+  const checkbox = screen.getByRole("checkbox");
+
+  await userEvent.tripleClick(checkbox);
+
+  expect(onChange).toHaveBeenCalledTimes(3);
+  expect(checkbox).toBeChecked();
+});
+```
+
 ## Mouse movement
 
 ### hover()
@@ -55,6 +97,31 @@ hover(element: Element): Promise<void>
 pointer({target: element})
 ```
 
+```js
+const TestComponent = () => {
+  const [isHover, setIsHover] = useState(false);
+  return (
+    <div
+      style={{ backgroundColor: isHover ? "red" : "green" }}
+      onMouseEnter={() => setIsHover(true)}
+      onMouseLeave={() => setIsHover(false)}
+    >
+      Hover
+    </div>
+  );
+};
+
+test("hover", async () => {
+  render(<TestComponent />);
+
+  const hoverBox = screen.getByText("Hover");
+
+  await userEvent.hover(hoverBox);
+
+  expect(hoverBox).toHaveStyle({ backgroundColor: "red" });
+});
+```
+
 ### unhover()
 
 ```ts
@@ -63,6 +130,35 @@ unhover(element: Element): Promise<void>
 
 ```js
 pointer({target: element.ownerDocument.body})
+```
+
+```js
+const TestComponent = () => {
+  const [isHover, setIsHover] = useState(false);
+  return (
+    <div
+      style={{ backgroundColor: isHover ? "red" : "green" }}
+      onMouseEnter={() => setIsHover(true)}
+      onMouseLeave={() => setIsHover(false)}
+    >
+      Hover
+    </div>
+  );
+};
+
+test("unhover", async () => {
+  render(<TestComponent />);
+
+  const hoverBox = screen.getByText("Hover");
+
+  await userEvent.hover(hoverBox);
+
+  expect(hoverBox).toHaveStyle({ backgroundColor: "red" });
+
+  await userEvent.unhover(hoverBox);
+
+  expect(hoverBox).toHaveStyle({ backgroundColor: "green" });
+});
 ```
 
 ## Keyboard
@@ -80,4 +176,41 @@ keyboard('{Tab}')
 keyboard('{Shift>}{Tab}{/Shift}')
 // with shift=false
 keyboard('[/ShiftLeft][/ShiftRight]{Tab}')
+```
+
+```js
+test("tab", async () => {
+  render(
+    <div>
+      <input data-testid="element" type="checkbox" />
+      <input data-testid="element" type="radio" />
+      <input data-testid="element" type="number" />
+    </div>
+  );
+
+  const [checkbox, radio, number] = screen.getAllByTestId("element");
+
+  expect(document.body).toHaveFocus();
+
+  await userEvent.tab();
+
+  expect(checkbox).toHaveFocus();
+
+  await userEvent.tab();
+
+  expect(radio).toHaveFocus();
+
+  await userEvent.tab();
+
+  expect(number).toHaveFocus();
+
+  await userEvent.tab();
+
+  // cycle goes back to the body element
+  expect(document.body).toHaveFocus();
+
+  await userEvent.tab();
+
+  expect(checkbox).toHaveFocus();
+});
 ```

--- a/docs/user-event/api-convenience.mdx
+++ b/docs/user-event/api-convenience.mdx
@@ -19,17 +19,17 @@ pointer([{target: element}, {keys: '[MouseLeft]', target: element}])
 ```
 
 ```js
-test("click", async () => {
-  render(
-    <div>
-      <label htmlFor="checkbox">Check</label>
-      <input id="checkbox" type="checkbox" />
-    </div>
-  );
+test('click', async () => {
+  const onChange = jest.fn()
+  render(<input type="checkbox" onChange={onChange} />)
 
-  await userEvent.click(screen.getByText("Check"));
-  expect(screen.getByLabelText("Check")).toBeChecked();
-});
+  const checkbox = screen.getByRole('checkbox')
+
+  await userEvent.click(checkbox)
+
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(checkbox).toBeChecked()
+})
 ```
 
 The first action might be skipped per [`skipHover`](options.mdx#skiphover).
@@ -45,17 +45,17 @@ pointer([{target: element}, {keys: '[MouseLeft][MouseLeft]', target: element}])
 ```
 
 ```js
-test("double click", async () => {
-  const onChange = jest.fn();
-  render(<input type="checkbox" onChange={onChange} />);
+test('double click', async () => {
+  const onChange = jest.fn()
+  render(<input type="checkbox" onChange={onChange} />)
 
-  const checkbox = screen.getByRole("checkbox");
+  const checkbox = screen.getByRole('checkbox')
 
-  await userEvent.dblClick(checkbox);
+  await userEvent.dblClick(checkbox)
 
-  expect(onChange).toHaveBeenCalledTimes(2);
-  expect(checkbox).not.toBeChecked();
-});
+  expect(onChange).toHaveBeenCalledTimes(2)
+  expect(checkbox).not.toBeChecked()
+})
 ```
 
 ### tripleClick()
@@ -72,17 +72,17 @@ pointer([
 ```
 
 ```js
-test("triple click", async () => {
-  const onChange = jest.fn();
-  render(<input type="checkbox" onChange={onChange} />);
+test('triple click', async () => {
+  const onChange = jest.fn()
+  render(<input type="checkbox" onChange={onChange} />)
 
-  const checkbox = screen.getByRole("checkbox");
+  const checkbox = screen.getByRole('checkbox')
 
-  await userEvent.tripleClick(checkbox);
+  await userEvent.tripleClick(checkbox)
 
-  expect(onChange).toHaveBeenCalledTimes(3);
-  expect(checkbox).toBeChecked();
-});
+  expect(onChange).toHaveBeenCalledTimes(3)
+  expect(checkbox).toBeChecked()
+})
 ```
 
 ## Mouse movement
@@ -99,27 +99,27 @@ pointer({target: element})
 
 ```js
 const TestComponent = () => {
-  const [isHover, setIsHover] = useState(false);
+  const [isHover, setIsHover] = useState(false)
   return (
     <div
-      style={{ backgroundColor: isHover ? "red" : "green" }}
+      style={{backgroundColor: isHover ? 'red' : 'green'}}
       onMouseEnter={() => setIsHover(true)}
       onMouseLeave={() => setIsHover(false)}
     >
       Hover
     </div>
-  );
-};
+  )
+}
 
-test("hover", async () => {
-  render(<TestComponent />);
+test('hover', async () => {
+  render(<TestComponent />)
 
-  const hoverBox = screen.getByText("Hover");
+  const hoverBox = screen.getByText('Hover')
 
-  await userEvent.hover(hoverBox);
+  await userEvent.hover(hoverBox)
 
-  expect(hoverBox).toHaveStyle({ backgroundColor: "red" });
-});
+  expect(hoverBox).toHaveStyle({backgroundColor: 'red'})
+})
 ```
 
 ### unhover()
@@ -134,31 +134,31 @@ pointer({target: element.ownerDocument.body})
 
 ```js
 const TestComponent = () => {
-  const [isHover, setIsHover] = useState(false);
+  const [isHover, setIsHover] = useState(false)
   return (
     <div
-      style={{ backgroundColor: isHover ? "red" : "green" }}
+      style={{backgroundColor: isHover ? 'red' : 'green'}}
       onMouseEnter={() => setIsHover(true)}
       onMouseLeave={() => setIsHover(false)}
     >
       Hover
     </div>
-  );
-};
+  )
+}
 
-test("unhover", async () => {
-  render(<TestComponent />);
+test('unhover', async () => {
+  render(<TestComponent />)
 
-  const hoverBox = screen.getByText("Hover");
+  const hoverBox = screen.getByText('Hover')
 
-  await userEvent.hover(hoverBox);
+  await userEvent.hover(hoverBox)
 
-  expect(hoverBox).toHaveStyle({ backgroundColor: "red" });
+  expect(hoverBox).toHaveStyle({backgroundColor: 'red'})
 
-  await userEvent.unhover(hoverBox);
+  await userEvent.unhover(hoverBox)
 
-  expect(hoverBox).toHaveStyle({ backgroundColor: "green" });
-});
+  expect(hoverBox).toHaveStyle({backgroundColor: 'green'})
+})
 ```
 
 ## Keyboard
@@ -179,38 +179,38 @@ keyboard('[/ShiftLeft][/ShiftRight]{Tab}')
 ```
 
 ```js
-test("tab", async () => {
+test('tab', async () => {
   render(
     <div>
       <input data-testid="element" type="checkbox" />
       <input data-testid="element" type="radio" />
       <input data-testid="element" type="number" />
-    </div>
-  );
+    </div>,
+  )
 
-  const [checkbox, radio, number] = screen.getAllByTestId("element");
+  const [checkbox, radio, number] = screen.getAllByTestId('element')
 
-  expect(document.body).toHaveFocus();
+  expect(document.body).toHaveFocus()
 
-  await userEvent.tab();
+  await userEvent.tab()
 
-  expect(checkbox).toHaveFocus();
+  expect(checkbox).toHaveFocus()
 
-  await userEvent.tab();
+  await userEvent.tab()
 
-  expect(radio).toHaveFocus();
+  expect(radio).toHaveFocus()
 
-  await userEvent.tab();
+  await userEvent.tab()
 
-  expect(number).toHaveFocus();
+  expect(number).toHaveFocus()
 
-  await userEvent.tab();
+  await userEvent.tab()
 
   // cycle goes back to the body element
-  expect(document.body).toHaveFocus();
+  expect(document.body).toHaveFocus()
 
-  await userEvent.tab();
+  await userEvent.tab()
 
-  expect(checkbox).toHaveFocus();
-});
+  expect(checkbox).toHaveFocus()
+})
 ```


### PR DESCRIPTION
I wrote the example code for the "user-event/Convenience APIs".

[user-event v13](https://testing-library.com/docs/ecosystem-user-event)  I think it would be helpful for more people to have example code like on the page.

Except for "hover" and "unhover", this is based on the [user-event v13](https://testing-library.com/docs/ecosystem-user-event) example code.

The example code all passes the tests fine.

<img width="345" alt="스크린샷 2023-07-21 오후 10 04 52" src="https://github.com/testing-library/testing-library-docs/assets/64779472/898d1e72-4533-4c65-b275-56df30efe815">
