### PR TITLE
fix(a11y): reducing homepage accessibility issues by 64%

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -152,12 +152,14 @@ export default class Index extends React.Component {
             image: `${baseUrl}img/wrench-128x128.png`,
             imageAlign: 'top',
             title: 'Write Maintainable Tests',
+            imageAlt: '',
           },
           {
             content: 'Interact with your app the same way as your users',
             image: `${baseUrl}img/check-128x128.png`,
             imageAlign: 'top',
             title: 'Develop with Confidence',
+            imageAlt: '',
           },
           {
             content:
@@ -165,6 +167,7 @@ export default class Index extends React.Component {
             image: `${baseUrl}img/tada-128x128.png`,
             imageAlign: 'top',
             title: 'Accessible by Default',
+            imageAlt: '',
           },
         ]}
       </Block>
@@ -177,61 +180,73 @@ export default class Index extends React.Component {
             image: `${baseUrl}img/react-128x128.png`,
             imageAlign: 'top',
             title: '[React](./docs/react-testing-library/intro)',
+            imageAlt: 'React logo',
           },
           {
             image: `${baseUrl}img/cypress-128x128.png`,
             imageAlign: 'top',
             title: '[Cypress](./docs/cypress-testing-library/intro)',
+            imageAlt: 'Cypress logo',
           },
           {
             image: `${baseUrl}img/testcafe-128x128.jpg`,
             imageAlign: 'top',
             title: `[Testcafe](./docs/testcafe-testing-library/intro)`,
+            imageAlt: 'Testcafe logo',
           },
           {
             image: `${baseUrl}img/svelte-logo.png`,
             imageAlign: 'top',
             title: '[Svelte](./docs/svelte-testing-library/intro)',
+            imageAlt: 'Svelte logo',
           },
           {
             image: `${baseUrl}img/vue-400x400.png`,
             imageAlign: 'top',
             title: '[Vue](./docs/vue-testing-library/intro)',
+            imageAlt: 'Vue logo',
           },
           {
             image: `${baseUrl}img/angular-250x250.png`,
             imageAlign: 'top',
             title: '[Angular](./docs/angular-testing-library/intro)',
+            imageAlt: 'Angular logo',
           },
           {
             image: `${baseUrl}img/reason-200x200.png`,
             imageAlign: 'top',
             title: '[ReasonReact](./docs/bs-react-testing-library/intro)',
+            imageAlt: 'ReasonReact logo',
           },
           {
             image: `${baseUrl}img/puppeteer-275x275.png`,
             imageAlign: 'top',
             title: '[Puppeteer](./docs/pptr-testing-library/intro)',
+            imageAlt: 'Puppeteer logo',
           },
           {
             image: `${baseUrl}img/react-native-128x128.png`,
             imageAlign: 'top',
             title: '[React Native](./docs/react-native-testing-library/intro)',
+            imageAlt: 'React Native logo',
           },
           {
             image: `${baseUrl}img/preact-128x128.png`,
             imageAlign: 'top',
             title: '[Preact](./docs/preact-testing-library/intro)',
+            imageAlt: 'Preact logo',
           },
           {
             image: `${baseUrl}img/nightwatch-128x128.png`,
             imageAlign: 'top',
             title: '[Nightwatch](./docs/nightwatch-testing-library/intro)',
+            imageAlt: 'Nightwatch logo',
           },
           {
             image: `${baseUrl}img/construction-128x128.png`,
             imageAlign: 'top',
             title: '[And more...](./docs/ecosystem-user-event)',
+            imageAlt: '',
           },
         ]}
       </Block>


### PR DESCRIPTION
## Description
- adding alt attributes to images for accessibility compliance
- tags that are for decorative purposes have an empty alt attribute

## Before
![before](https://github.com/testing-library/testing-library-docs/assets/11414958/2d595b26-5df7-4015-b66e-3845e5f6a381)

## After
![after](https://github.com/testing-library/testing-library-docs/assets/11414958/1289a2f7-82d7-4ea0-9214-45df08e915ef)
