### PR TITLE
Fix capitalization

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -31,8 +31,8 @@ make your test util file accessible without using relative paths.
 The example below sets up data providers using the [`wrapper`](api.mdx#wrapper)
 option to `render`.
 
-  <Tabs groupId="test-utils" defaultValue="jsx" values={[ {label: 'Javascript',
-  value: 'jsx'}, {label: 'Typescript', value: 'tsx'}, ]}>
+  <Tabs groupId="test-utils" defaultValue="jsx" values={[ {label: 'JavaScript',
+  value: 'jsx'}, {label: 'TypeScript', value: 'tsx'}, ]}>
 
   <TabItem value="jsx">
 
@@ -250,8 +250,8 @@ passing a [`queries`](api.mdx#render-options) option.
 If you want to add custom queries globally, you can do this by defining your customized
 `render`, `screen` and `within` methods:
 
-  <Tabs groupId="test-utils" defaultValue="jsx" values={[ {label: 'Javascript',
-  value: 'jsx'}, {label: 'Typescript', value: 'tsx'}, ]}>
+  <Tabs groupId="test-utils" defaultValue="jsx" values={[ {label: 'JavaScript',
+  value: 'jsx'}, {label: 'TypeScript', value: 'tsx'}, ]}>
 
   <TabItem value="jsx">
 

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -171,9 +171,9 @@ You can take a look at the [`vitest-svelte-kit` configuration docs](https://gith
     npm run test
     ```
 
-### Typescript
+### TypeScript
 
-To use Typescript with Jest, you'll need to install and configure `svelte-preprocess` and
+To use TypeScript with Jest, you'll need to install and configure `svelte-preprocess` and
 `ts-jest`. For full instructions, see the
 [`svelte-jester`](https://github.com/mihar-22/svelte-jester#typescript) docs.
 

--- a/docs/webdriverio-testing-library/intro.mdx
+++ b/docs/webdriverio-testing-library/intro.mdx
@@ -162,7 +162,7 @@ it('lets you configure queries', async () => {
 })
 ```
 
-## Typescript
+## TypeScript
 
 This library comes with full typescript definitions. To use the commands added
 by [`setupBrowser`](#setupbrowser) the `Browser` and `Element` interfaces in the


### PR DESCRIPTION
Just a couple of quick capitalization fixes:

- `Javascript` -> `JavaScript`
- `Typescript` -> `TypeScript`