### PR TITLE
fix: use correct control modifier

### DIFF
--- a/docs/ecosystem-user-event.mdx
+++ b/docs/ecosystem-user-event.mdx
@@ -177,14 +177,14 @@ The following special character strings are supported:
 | `{home}`       | Home       | N/A                |                                                                                                                                                                     |
 | `{end}`        | End        | N/A                |                                                                                                                                                                     |
 | `{shift}`      | Shift      | `shiftKey`         | Does **not** capitalize following characters.                                                                                                                       |
-| `{ctrl}`       | Control    | `ctrlKey`          |                                                                                                                                                                     |
+| `{control}`    | Control    | `ctrlKey`          |                                                                                                                                                                     |
 | `{alt}`        | Alt        | `altKey`           |                                                                                                                                                                     |
 | `{meta}`       | OS         | `metaKey`          |                                                                                                                                                                     |
 | `{capslock}`   | CapsLock   | `modifierCapsLock` | Fires both keydown and keyup when used (simulates a user clicking their "Caps Lock" button to enable caps lock).                                                    |
 
-> **A note about modifiers:** Modifier keys (`{shift}`, `{ctrl}`, `{alt}`,
+> **A note about modifiers:** Modifier keys (`{shift}`, `{control}`, `{alt}`,
 > `{meta}`) will activate their corresponding event modifiers for the duration
-> of type command or until they are closed (via `{/shift}`, `{/ctrl}`, etc.). If
+> of type command or until they are closed (via `{/shift}`, `{/control}`, etc.). If
 > they are not closed explicitly, then events will be fired to close them
 > automatically (to disable this, set the `skipAutoClose` option to `true`).
 
@@ -301,7 +301,7 @@ Keystrokes can be described:
   (note the lowercase) will automatically be kept pressed, just like before. You
   can cancel this behavior by adding a `/` to the end of the descriptor.
   ```js
-  userEvent.keyboard('{shift}{ctrl/}a{/shift}') // translates to: Shift(down), Control(down+up), a, Shift(up)
+  userEvent.keyboard('{shift}{control/}a{/shift}') // translates to: Shift(down), Control(down+up), a, Shift(up)
   ```
 
 Keys can be kept pressed by adding a `>` to the end of the descriptor - and


### PR DESCRIPTION
I was creating a test and `{Ctrl}` wasn't working. I searched through the code and found that the correct modifier is`{Control}`, as you can see in [user-event/tests/keyboard/parseKeyDef.ts](https://github.com/testing-library/user-event/blob/7a305dee9ab833d6f338d567fc2e862b4838b76a/tests/keyboard/parseKeyDef.ts#L30) and [user-events/tests/utility/type.ts](https://github.com/testing-library/user-event/blob/7a305dee9ab833d6f338d567fc2e862b4838b76a/tests/utility/type.ts#L72).