### PR TITLE
docs: add CLI Testing Library to ecosystem

### DIFF
--- a/docs/ecosystem-cli-testing-library.mdx
+++ b/docs/ecosystem-cli-testing-library.mdx
@@ -1,0 +1,48 @@
+---
+id: ecosystem-cli-testing-library
+title: cli-testing-library
+---
+
+[`CLI Testing Library`](https://github.com/crutchcorn/cli-testing-library) is a
+companion library to `Testing Library` that aims to mimic the API of
+`Testing Library` for testing CLI applications.
+
+```bash npm2yarn
+npm install --save-dev cli-testing-library
+```
+
+```js
+import {resolve} from 'path'
+import {render} from 'cli-testing-library'
+
+test('Is able to make terminal input and view in-progress stdout', async () => {
+  const {clear, findByText, queryByText, userEvent} = await render('node', [
+    resolve(__dirname, './execute-scripts/stdio-inquirer.js'),
+  ])
+
+  const instance = await findByText('First option')
+
+  expect(instance).toBeInTheConsole()
+
+  expect(await findByText('❯ One')).toBeInTheConsole()
+
+  clear()
+
+  userEvent('[ArrowDown]')
+
+  expect(await findByText('❯ Two')).toBeInTheConsole()
+
+  clear()
+
+  userEvent.keyboard('[Enter]')
+
+  expect(await findByText('First option: Two')).toBeInTheConsole()
+  expect(await queryByText('First option: Three')).not.toBeInTheConsole()
+})
+```
+
+Check out
+[CLI Testing Library's documentation](https://github.com/crutchcorn/cli-testing-library)
+for a full list of its API.
+
+- [CLI Testing Library on GitHub](https://github.com/crutchcorn/cli-testing-library)

--- a/sidebars.js
+++ b/sidebars.js
@@ -202,6 +202,7 @@ module.exports = {
         'ecosystem-query-extensions',
         'ecosystem-rtl-simple-queries',
         'ecosystem-testing-library-selector',
+        'ecosystem-cli-testing-library',
       ],
     },
   ],


### PR DESCRIPTION
Per a conversation I had with @nickmccurdy, I've added my CLI Testing Library project to the ecosystem section of the website.

This was suggested by @kentcdodds as well on X/Twitter: https://twitter.com/kentcdodds/status/1688782457838112768

Closes #1069