### PR TITLE
fix: link text and url of chrome extension

### DIFF
--- a/docs/queries/about.mdx
+++ b/docs/queries/about.mdx
@@ -390,12 +390,12 @@ const foo = container.querySelector('[data-foo="bar"]')
 
 Do you still have problems knowing how to use Testing Library queries?
 
-There is a very cool Browser extension for
-[Chrome](https://chrome.google.com/webstore/detail/testing-playground/hejbmebodbijjdhflfknehhcgaklhano/related)
-named Testing Playground, and it helps you find the best queries to select
-elements. It allows you to inspect the element hierarchies in the Browser's
-Developer Tools, and provides you with suggestions on how to select them, while
-encouraging good testing practices.
+There is a very cool Browser extension for Chrome named
+[Testing Playground](https://chrome.google.com/webstore/detail/testing-playground/hejbmebodbijjdhflfknehhcgaklhano),
+and it helps you find the best queries to select elements. It allows you to
+inspect the element hierarchies in the Browser's Developer Tools, and provides
+you with suggestions on how to select them, while encouraging good testing
+practices.
 
 ## Playground
 


### PR DESCRIPTION
- Change the link text from `Chrome` to `Testing Playground`
- Remove `/related` from the URL