### PR TITLE
fix documentation: fix angular challenge url

### DIFF
--- a/docs/learning.mdx
+++ b/docs/learning.mdx
@@ -46,7 +46,7 @@ sidebar_label: Learning Material
 - [Enzyme vs React Testing Library: A Migration Guide](https://claritydev.net/blog/enzyme-vs-react-testing-library-migration-guide) by [Alex Khomenko](https://claritydev.net)
 - [Testing React Hook Form With React Testing Library](https://claritydev.net/blog/testing-react-hook-form-with-react-testing-library) by [Alex Khomenko](https://claritydev.net)
 - [Improving React Testing Library Tests](https://claritydev.net/blog/improving-react-testing-library-tests) by [Alex Khomenko](https://claritydev.net)   
-- [Testing Angular Challenges](https://github.com/tomalaforge/angular-challenges/blob/main/README.test.md) by [Thomas Laforge](https://twitter.com/laforge_toma)
+- [Testing Angular Challenges](https://angular-challenges.vercel.app/challenges/testing/) by [Thomas Laforge](https://twitter.com/laforge_toma)
 
 ## Portuguese 🇧🇷
 


### PR DESCRIPTION
I created a site for my angular challenges. There is a page specific for testing purposes and nicer than a readme file. 