### PR TITLE
imp: add unmount top link

### DIFF
--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -325,12 +325,6 @@ All it does is forward all arguments to the act function if your version of
 react supports `act`. It is recommended to use the import from
 `@testing-library/react` over `react-dom/test-utils` for consistency reasons.
 
-```typescript
-export const act: typeof reactAct extends undefined
-  ? (callback: () => void) => void
-  : typeof reactAct
-```
-
 ## `renderHook`
 
 This is a convenience wrapper around `render` with a custom test component. The

--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -31,6 +31,7 @@ as these methods:
 - [`renderHook` Result](#renderhook-result)
   - [`result`](#result)
   - [`rerender`](#rerender-1)
+  - [`unmount`](#unmount-1)
 
 ---
 
@@ -323,6 +324,12 @@ This is a light wrapper around the
 All it does is forward all arguments to the act function if your version of
 react supports `act`. It is recommended to use the import from
 `@testing-library/react` over `react-dom/test-utils` for consistency reasons.
+
+```typescript
+export const act: typeof reactAct extends undefined
+  ? (callback: () => void) => void
+  : typeof reactAct
+```
 
 ## `renderHook`
 


### PR DESCRIPTION
https://github.com/testing-library/testing-library-docs/pull/1319
I added the `unmount` part of the `renderHook`, but didn't get around to adding the top link, so I worked on that. 