### PR TITLE
Highlights necessary step in Svelte setup

### DIFF
--- a/docs/preact-testing-library/api.mdx
+++ b/docs/preact-testing-library/api.mdx
@@ -54,6 +54,7 @@ Unmounts the component from the container and destroys the container.
 
 > This is called automatically if your testing framework (such as mocha, Jest or
 > Jasmine) injects a global `afterEach()` function into the testing environment.
+> If not, you will need to call `cleanup()` after each test.
 
 If you'd like to disable this then set `process.env.PTL_SKIP_AUTO_CLEANUP` to
 true when running your tests.

--- a/docs/preact-testing-library/api.mdx
+++ b/docs/preact-testing-library/api.mdx
@@ -52,9 +52,11 @@ const {results} = render(<YourComponent />, {options})
 
 Unmounts the component from the container and destroys the container.
 
-📝 When you import anything from the library, this automatically runs after each
-test. If you'd like to disable this then set `process.env.PTL_SKIP_AUTO_CLEANUP`
-to true when running your tests.
+> This is called automatically if your testing framework (such as mocha, Jest or
+> Jasmine) injects a global `afterEach()` function into the testing environment.
+
+If you'd like to disable this then set `process.env.PTL_SKIP_AUTO_CLEANUP` to
+true when running your tests.
 
 ```jsx
 import {render, cleanup} from '@testing-library/preact'

--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -291,6 +291,7 @@ Unmounts React trees that were mounted with [render](#render).
 
 > This is called automatically if your testing framework (such as mocha, Jest or
 > Jasmine) injects a global `afterEach()` function into the testing environment.
+> If not, you will need to call `cleanup()` after each test.
 
 For example, if you're using the [ava](https://github.com/avajs/ava) testing
 framework, then you would need to use the `test.afterEach` hook like so:

--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -289,10 +289,8 @@ expect(firstRender).toMatchDiffSnapshot(asFragment())
 
 Unmounts React trees that were mounted with [render](#render).
 
-> Please note that this is done automatically if the testing framework you're
-> using supports the `afterEach` global and it is injected to your testing
-> environment (like mocha, Jest, and Jasmine). If not, you will need to do
-> manual cleanups after each test.
+> This is called automatically if your testing framework (such as mocha, Jest or
+> Jasmine) injects a global `afterEach()` function into the testing environment.
 
 For example, if you're using the [ava](https://github.com/avajs/ava) testing
 framework, then you would need to use the `test.afterEach` hook like so:

--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -70,8 +70,8 @@ const {results} = render(YourComponent, {myProp: 'value'})
 
 ## `cleanup`
 
-> You don't need to import or use this, it's done automagically for you with
-> `globals: true` in your test config!
+> This is called automatically if your testing framework (such as mocha, Jest or
+> Jasmine) injects a global `afterEach()` function into the testing environment.
 
 Unmounts the component from the container and destroys the container.
 

--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -70,7 +70,7 @@ const {results} = render(YourComponent, {myProp: 'value'})
 
 ## `cleanup`
 
-> You don't need to import or use this, it's done automagically for you!
+> You don't need to import or use this, it's done automagically for you with `globals: true` in your test config!
 
 Unmounts the component from the container and destroys the container.
 

--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -70,7 +70,8 @@ const {results} = render(YourComponent, {myProp: 'value'})
 
 ## `cleanup`
 
-> You don't need to import or use this, it's done automagically for you with `globals: true` in your test config!
+> You don't need to import or use this, it's done automagically for you with
+> `globals: true` in your test config!
 
 Unmounts the component from the container and destroys the container.
 

--- a/docs/svelte-testing-library/api.mdx
+++ b/docs/svelte-testing-library/api.mdx
@@ -72,6 +72,7 @@ const {results} = render(YourComponent, {myProp: 'value'})
 
 > This is called automatically if your testing framework (such as mocha, Jest or
 > Jasmine) injects a global `afterEach()` function into the testing environment.
+> If not, you will need to call `cleanup()` after each test.
 
 Unmounts the component from the container and destroys the container.
 

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -46,7 +46,7 @@ npm install --save-dev @vitest/ui
    npm install --save-dev @sveltejs/vite-plugin-svelte vite
    ```
 
-3. Add a `vitest.config.ts` configuration file to the root of your project
+3. Add a `vitest.config.ts` configuration file to the root of your project. Add `globals: true` so `cleanup()` runs after each test.
 
    ```js
    import {defineConfig} from 'vitest/config'
@@ -55,7 +55,7 @@ npm install --save-dev @vitest/ui
    export default defineConfig({
      plugins: [svelte({hot: !process.env.VITEST})],
      test: {
-       globals: true,
+       globals: true
        environment: 'jsdom',
      },
    })

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -46,7 +46,8 @@ npm install --save-dev @vitest/ui
    npm install --save-dev @sveltejs/vite-plugin-svelte vite
    ```
 
-3. Add a `vitest.config.ts` configuration file to the root of your project. Add `globals: true` so `cleanup()` runs after each test.
+3. Add a `vitest.config.ts` configuration file to the root of your project. Add
+   `globals: true` so `cleanup()` runs after each test.
 
    ```js
    import {defineConfig} from 'vitest/config'

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -55,7 +55,7 @@ npm install --save-dev @vitest/ui
    export default defineConfig({
      plugins: [svelte({hot: !process.env.VITEST})],
      test: {
-       globals: true
+       globals: true,
        environment: 'jsdom',
      },
    })

--- a/docs/vue-testing-library/api.mdx
+++ b/docs/vue-testing-library/api.mdx
@@ -232,9 +232,8 @@ See a working example of `update` in the
 Unmounts Vue trees that were mounted with
 [render](#rendercomponent-options-callback).
 
-> If you are using an environment that supports `afterEach` hook (as in Jest),
-> there's no need to call `cleanup` manually. Vue Testing Library handles it for
-> you.
+> This is called automatically if your testing framework (such as mocha, Jest or
+> Jasmine) injects a global `afterEach()` function into the testing environment.
 
 Failing to call `cleanup` when you've called `render` could result in a memory
 leak and tests which are not idempotent (which can lead to difficult to debug

--- a/docs/vue-testing-library/api.mdx
+++ b/docs/vue-testing-library/api.mdx
@@ -234,6 +234,7 @@ Unmounts Vue trees that were mounted with
 
 > This is called automatically if your testing framework (such as mocha, Jest or
 > Jasmine) injects a global `afterEach()` function into the testing environment.
+> If not, you will need to call `cleanup()` after each test.
 
 Failing to call `cleanup` when you've called `render` could result in a memory
 leak and tests which are not idempotent (which can lead to difficult to debug


### PR DESCRIPTION
@testing-library/svelte requires `globals: true` to run `cleanup()` after each test, but this is [a bit easy to miss in the docs](https://github.com/testing-library/testing-library-docs/issues/1331). This PR highlights this required step. 