### PR TITLE
Update user event's delay option to say milliseconds instead of seconds

### DIFF
--- a/docs/user-event/options.mdx
+++ b/docs/user-event/options.mdx
@@ -38,7 +38,7 @@ The feature therefore will not constitute a breaking change.
 ### delay
 
 Between some subsequent inputs like typing a series of characters the code
-execution is delayed per `setTimeout` for (at least) `delay` seconds.
+execution is delayed per `setTimeout` for (at least) `delay` milliseconds.
 
 This moves the next changes at least to the next macro task and allows other
 (asynchronous) code to run between events.


### PR DESCRIPTION
The delay value gets passed into setTimeout which takes a value in milliseconds (not seconds).

fixes #1335