### PR TITLE
For search-engine optimization, rename ecosystem-user-event to user-e…

### DIFF
--- a/docs/user-event/intro.mdx
+++ b/docs/user-event/intro.mdx
@@ -11,7 +11,7 @@ events that would happen if the interaction took place in a browser.
 
 These docs describe `user-event@14`. We recommend updating your projects to this
 version, as it includes important bug fixes and new features. You can find the
-docs for `user-event@13.5.0` [here](../ecosystem-user-event.mdx), and the
+docs for `user-event@13.5.0` [here](./v13.mdx), and the
 changelog for the release
 [here](https://github.com/testing-library/user-event/releases/tag/v14.0.0).
 

--- a/docs/user-event/v13.mdx
+++ b/docs/user-event/v13.mdx
@@ -1,5 +1,5 @@
 ---
-id: ecosystem-user-event
+id: v13
 title: user-event v13
 ---
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -60,6 +60,10 @@
 [[redirects]]
   from = "/docs/dom-testing-library/api-helpers"
   to = "/docs/dom-testing-library/api-accessibility"
+[[redirects]]
+  from = "/docs/ecosystem-user-event"
+  to = "/docs/user-event/intro"
+
 
 # Reorganization (do not redirect if route is not 404)
 [[redirects]]

--- a/sidebars.js
+++ b/sidebars.js
@@ -186,7 +186,7 @@ module.exports = {
         'user-event/clipboard',
         'user-event/utility',
         'user-event/convenience',
-        'ecosystem-user-event',
+        'user-event/v13',
       ],
     },
     {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -245,7 +245,7 @@ export default class Index extends React.Component {
           {
             image: `${baseUrl}img/construction-128x128.png`,
             imageAlign: 'top',
-            title: '[And more...](./docs/user-event/v13)',
+            title: '[And more...](./docs/user-event/intro)',
             imageAlt: '',
           },
         ]}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -245,7 +245,7 @@ export default class Index extends React.Component {
           {
             image: `${baseUrl}img/construction-128x128.png`,
             imageAlign: 'top',
-            title: '[And more...](./docs/ecosystem-user-event)',
+            title: '[And more...](./docs/user-event/v13)',
             imageAlt: '',
           },
         ]}


### PR DESCRIPTION
This PR does the following:
* Moves `docs/ecosystem-user-event` to `docs/user-event/v13`
* Updates links accordingly in [docs/user-event/intro.mdx](https://github.com/testing-library/testing-library-docs/compare/main...smk267:testing-library-docs:all-contributors/smk267/user-event-docs-redirect-and-rename?expand=1#diff-0827ef9664822fb9456163a9a6b7bfbc01f87e61e99d8efe75dc832d3498281b), [src/pages/index.js](https://github.com/testing-library/testing-library-docs/compare/main...smk267:testing-library-docs:all-contributors/smk267/user-event-docs-redirect-and-rename?expand=1#diff-26ca35c3be6d07c84bb77f1e63a1b19487279d5b9c9a9392179b3a35647e1254), and [sidebars.js](https://github.com/testing-library/testing-library-docs/compare/main...smk267:testing-library-docs:all-contributors/smk267/user-event-docs-redirect-and-rename?expand=1#diff-9a6a0fdafefb0eecffb77784bc94f5ad984062167b8bcb7c4a899c90f6f567e8).
* Adds redirection from `"/docs/ecosystem-user-event"` to `"/docs/user-event/v13"`