### PR TITLE
chore: Improve docs with removing misleading statement on query API i…

### DIFF
--- a/docs/cypress-testing-library/intro.mdx
+++ b/docs/cypress-testing-library/intro.mdx
@@ -22,8 +22,7 @@ Add this line to your project's `cypress/support/commands.js`:
 import '@testing-library/cypress/add-commands'
 ```
 
-You can now use all of `DOM Testing Library`'s `findBy`, `findAllBy`, `queryBy`
-and `queryAllBy` commands off the global `cy` object.
+You can now use some of `DOM Testing Library`'s `findBy`, and `findAllBy` commands off the global `cy` object.
 [See the `About queries` docs for reference](/docs/queries/about).
 
 > Note: the `get*` queries are not supported because for reasonable Cypress


### PR DESCRIPTION
Since in new versions of `@testing-library/cypress` we don't have `queryBy` and `queryAllBy` APIs its reasonable to remove them from docs.