### PR TITLE
docs: add redirect to new rtl template

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -32,6 +32,11 @@
   from = "/discord"
   to = "https://discord.gg/testing-library"
 
+# Shortcuts to reproduction templates
+[[redirects]]
+  from = "/new-rtl"
+  to = "https://stackblitz.com/edit/rtl-template"
+
 # Support page to help page
 [[redirects]]
   from = "/support"


### PR DESCRIPTION
This PR adds a new redirect to RTL template for reproductions
IMO, we can create more templates (DTL, ATL and more).
I can definitely take the DTL if we want.