### PR TITLE
docs: add redirect to dtl template

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -36,6 +36,9 @@
 [[redirects]]
   from = "/new-rtl"
   to = "https://stackblitz.com/edit/rtl-template"
+[[redirects]]
+  from = "/new-dtl"
+  to = "https://stackblitz.com/edit/dtl-template"
 
 # Support page to help page
 [[redirects]]


### PR DESCRIPTION
This PR is a followup to https://github.com/testing-library/testing-library-docs/pull/1346 and adds DTL template.
I'll now work on an ATL template.