### PR TITLE
docs: add query ByRole performance notes

### DIFF
--- a/docs/queries/byrole.mdx
+++ b/docs/queries/byrole.mdx
@@ -462,3 +462,20 @@ You can query a specific element like this
 ```js
 getByRole('alertdialog', {description: 'Your session is about to expire'})
 ```
+
+## Performance
+
+`getByRole` is the most preferred query to use as it most closely resembles the
+user experience, however the calculations it must perform to provide this
+confidence can be expensive (particularly with large DOM trees).
+
+Where test performance is a concern it may be desirable to trade some of this
+confidence for improved performance.
+
+`getByRole` performance can be improved by setting the option
+[`hidden`](#hidden) to `true` and thereby avoid expensive visibility checks.
+Note that in doing so inaccessible elements will now be included in the result.
+
+Another option may be to substitute `getByRole` for simpler `getByLabelText` and
+`getByText` queries which can be significantly faster though less robust
+alternatives.


### PR DESCRIPTION
Adds notes about performance of *ByRole queries to the Queries > ByRole page.

`getByRole` and the likes are known to be slow at times and documentation has been requested[^1][^2][^3] to help make this more visible.

This has been known for several years[^1] and performance remains a concern[^4] so I believe it is worthwhile adding to the docs. 

I think it's important to have a balance of conveying the importance of `getByRole` while still sharing this information about the performance so users can make an informed decision if performance is a problem.


This relates to issues
- https://github.com/testing-library/dom-testing-library/issues/820
- https://github.com/testing-library/dom-testing-library/issues/698

These issues have great discussion around this topic, which I've attempted to consolidate.

[^1]: https://github.com/testing-library/dom-testing-library/issues/820#issuecomment-726812393

[^2]: https://github.com/testing-library/dom-testing-library/issues/820#issuecomment-726980009

[^3]: https://github.com/testing-library/dom-testing-library/issues/820#issuecomment-726994803

[^4]: https://github.com/testing-library/dom-testing-library/issues/698
