### PR TITLE
Update example-intro.mdx

### DIFF
--- a/docs/react-testing-library/example-intro.mdx
+++ b/docs/react-testing-library/example-intro.mdx
@@ -155,34 +155,36 @@ component makes.
 ```js
 // declare which API requests to mock
 const server = setupServer(
-  // capture "GET /greeting" requests
-  rest.get('/greeting', (req, res, ctx) => {
-    // respond using a mocked JSON body
-    return res(ctx.json({greeting: 'hello there'}))
-  }),
-)
+  http.get("/greeting", () => {
+    return HttpResponse.json({
+      greeting: "Hello There",
+    });
+  })
+);
 
 // establish API mocking before all tests
-beforeAll(() => server.listen())
+beforeAll(() => server.listen());
 // reset any request handlers that are declared as a part of our tests
 // (i.e. for testing one-time error scenarios)
-afterEach(() => server.resetHandlers())
+afterEach(() => server.resetHandlers());
 // clean up once the tests are done
-afterAll(() => server.close())
+afterAll(() => server.close());
 
 // ...
 
-test('handles server error', async () => {
+test("handles server error", async () => {
   server.use(
     // override the initial "GET /greeting" request handler
     // to return a 500 Server Error
-    rest.get('/greeting', (req, res, ctx) => {
-      return res(ctx.status(500))
-    }),
-  )
+    http.get("/greeting", () => {
+      return new HttpResponse(null, { status: 500 });
+    })
+  );
 
   // ...
-})
+});
+```
+
 ```
 
 ### Arrange


### PR DESCRIPTION
Updating the MSW example to new syntax, removing `rest` for  http object.