### PR TITLE
angular: add deferBlockBehavior to the docs

### DIFF
--- a/docs/angular-testing-library/api.mdx
+++ b/docs/angular-testing-library/api.mdx
@@ -150,6 +150,42 @@ await render(AppComponent, {
 })
 ```
 
+### `deferBlockBehavior`
+
+Set the defer blocks behavior.
+
+For more info see the
+[Angular docs](https://angular.io/api/core/testing/DeferBlockBehavior)
+
+**default** : `undefined` (uses the Angular default, which is
+`DeferBlockBehavior.Manual`)
+
+**example**:
+
+```typescript
+await render(AppComponent, {
+  deferBlockBehavior: DeferBlockBehavior.Playthrough,
+})
+```
+
+### `deferBlockStates`
+
+Set the initial state of a deferrable blocks in a component.
+
+For more info see the
+[Angular docs](https://angular.io/api/core/testing/DeferBlockState)
+
+**default** : `undefined` (uses the Angular default, which is
+`DeferBlockState.Placeholder`)
+
+**example**:
+
+```typescript
+await render(FixtureComponent, {
+  deferBlockStates: DeferBlockState.Loading,
+})
+```
+
 ### `componentProviders`
 
 A collection of providers needed to render the component via Dependency


### PR DESCRIPTION
Angular is adding some more functionality around testing.
This was recently added in ATL (with https://github.com/testing-library/angular-testing-library/pull/431), this PR updates the documentation to add the new API.

While adding the new API, I also noticed `deferBlockStates` was undocumented.