### PR TITLE
react: legacyRoot is only supported in React <= 18

### DIFF
--- a/docs/react-testing-library/api.mdx
+++ b/docs/react-testing-library/api.mdx
@@ -107,6 +107,8 @@ your components.
 
 ### `legacyRoot`
 
+**WARNING**: This option is only available when tests run with React 18 and earlier.
+
 By default we'll render with support for concurrent features (i.e.
 [`ReactDOMClient.createRoot`](https://reactjs.org/docs/react-dom-client.html#createroot)).
 However, if you're dealing with a legacy app that requires rendering like in


### PR DESCRIPTION
Docs for https://github.com/testing-library/react-testing-library/pull/1294