### PR TITLE
docs: move dtl to peerdeps for rtl

### DIFF
--- a/docs/react-testing-library/intro.mdx
+++ b/docs/react-testing-library/intro.mdx
@@ -18,11 +18,11 @@ npm install --save-dev @testing-library/react @testing-library/dom
 
 ### With TypeScript
 
-To get full type coverage, you need to install the types for `react-dom` as
+To get full type coverage, you need to install the types for `react` and `react-dom` as 
 well:
 
 ```bash npm2yarn
-npm install --save-dev @testing-library/react @testing-library/dom @types/react-dom
+npm install --save-dev @testing-library/react @testing-library/dom @types/react @types/react-dom
 ```
 
 [gh]: https://github.com/testing-library/react-testing-library

--- a/docs/react-testing-library/intro.mdx
+++ b/docs/react-testing-library/intro.mdx
@@ -22,7 +22,7 @@ To get full type coverage, you need to install the types for `react-dom` as
 well:
 
 ```bash npm2yarn
-npm install --save-dev @testing-library/react @types/react-dom
+npm install --save-dev @testing-library/react @testing-library/dom @types/react-dom
 ```
 
 [gh]: https://github.com/testing-library/react-testing-library

--- a/docs/react-testing-library/intro.mdx
+++ b/docs/react-testing-library/intro.mdx
@@ -9,18 +9,21 @@ APIs for working with React components.
 
 ## Installation
 
+To get started with `React Testing Library`, you'll need to install it together
+with it's peerDependency `@testing-library/dom`:
+
 ```bash npm2yarn
-npm install --save-dev @testing-library/react
+npm install --save-dev @testing-library/react @testing-library/dom
 ```
 
 ### With TypeScript
 
-To get full type coverage, you need to install the types for `react-dom` as well:
+To get full type coverage, you need to install the types for `react-dom` as
+well:
 
 ```bash npm2yarn
 npm install --save-dev @testing-library/react @types/react-dom
 ```
-
 
 [gh]: https://github.com/testing-library/react-testing-library
 

--- a/docs/react-testing-library/intro.mdx
+++ b/docs/react-testing-library/intro.mdx
@@ -10,7 +10,7 @@ APIs for working with React components.
 ## Installation
 
 To get started with `React Testing Library`, you'll need to install it together
-with it's peerDependency `@testing-library/dom`:
+with its peerDependency `@testing-library/dom`:
 
 ```bash npm2yarn
 npm install --save-dev @testing-library/react @testing-library/dom


### PR DESCRIPTION
Docs for https://github.com/testing-library/react-testing-library/pull/1305

Explanation that we need to manually install `@testing-library/dom` as it's moved to peer dependency.

**Do not merge before merging the RTL PR** 