### PR TITLE
docs: recommend installing `@types/react`

### DIFF
--- a/docs/react-testing-library/intro.mdx
+++ b/docs/react-testing-library/intro.mdx
@@ -15,10 +15,10 @@ npm install --save-dev @testing-library/react
 
 ### With TypeScript
 
-To get full type coverage, you need to install the types for `react-dom` as well:
+To get full type coverage, you need to install the types for `react` and `react-dom` as well:
 
 ```bash npm2yarn
-npm install --save-dev @testing-library/react @types/react-dom
+npm install --save-dev @testing-library/react @types/react-dom @types/react
 ```
 
 


### PR DESCRIPTION
Following https://github.com/testing-library/react-testing-library/pull/1319