### PR TITLE
docs(svelte-testing-library): add Svelte 5 setup instructions for Jest

### DIFF
--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -171,7 +171,7 @@ you must use Jest in [ESM mode][jest esm mode].
 3. Configure Jest to use jsdom, transform Svelte files, and use your setup file
 
    ```js title="jest.config.js"
-   module.exports = {
+   export default {
      transform: {
        '^.+\\.svelte$': 'svelte-jester',
      },
@@ -181,6 +181,33 @@ you must use Jest in [ESM mode][jest esm mode].
      setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
    }
    ```
+
+   :::note
+
+   If you are using Svelte 5, you must use `svelte-jester@5` or later, and you
+   will need to make additional changes to your Jest configuration.
+
+   - Update `transform` to compile `.svelte.(js|ts)` modules
+   - Allow `@testing-library/svelte` to be transformed, even though it's in
+     `node_modules`
+
+   ```diff title="jest.config.js"
+     export default {
+       transform: {
+   -     '^.+\\.svelte$': 'svelte-jester',
+   +     '^.+\\.svelte(\\.(js|ts))?$': 'svelte-jester',
+       },
+   +   transformIgnorePatterns: [
+   +     '/node_modules/(?!@testing-library/svelte/)',
+   +   ],
+       moduleFileExtensions: ['js', 'svelte'],
+       extensionsToTreatAsEsm: ['.svelte'],
+       testEnvironment: 'jsdom',
+       setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
+     }
+   ```
+
+   :::
 
 4. Add the following to your `package.json`
 


### PR DESCRIPTION
Companion docs PR to testing-library/svelte-testing-library#375 and svelteness/svelte-jester#283. Svelte 5 introduces the concept of "Svelte modules," which are plain JS and TS files that are run through the Svelte compiler to add support for Svelte 5's "runes" reactivity system.

This is handled well in Vitest by Svelte's first-party `vite-plugin-svelte`, but requires additional setup to work in Jest.

This PR add newly required Svelte 5 setup instructions for Jest and notes that `svelte-jester >= 5` is now required. I'm going to keep this listed as a draft until I've merged and verified testing-library/svelte-testing-library#375 in some real-life projects. That being said, these additional `jest.config.js` changes will not cause any issues with existing Svelte 4 projects