### PR TITLE
docs: update docs for ATL v17

### DIFF
--- a/docs/angular-testing-library/intro.mdx
+++ b/docs/angular-testing-library/intro.mdx
@@ -8,9 +8,17 @@ sidebar_label: Introduction
 builds on top of
 [`DOM Testing Library`](https://github.com/testing-library/dom-testing-library)
 by adding APIs for working with Angular components.
+Starting from ATL version 17, you also need to install `@testing-library/dom`:
 
 ```bash npm2yarn
-npm install --save-dev @testing-library/angular
+npm install --save-dev @testing-library/angular @testing-library/dom
+```
+
+Or, you can use the `ng add` command.
+This sets up your project to use Angular Testing Library, which also includes the installation of `@testing-library/dom`.
+
+```bash
+ng add @testing-library/angular
 ```
 
 - [`@testing-library/angular-testing-library` on GitHub](https://github.com/testing-library/angular-testing-library)

--- a/docs/angular-testing-library/version-compatibility.mdx
+++ b/docs/angular-testing-library/version-compatibility.mdx
@@ -6,10 +6,11 @@ title: Version compatibility
 An overview of the compatibility between different versions of Angular Testing
 Library and Angular.
 
-| Angular | Angular Testing Library |
-| ------- | ----------------------- |
-| 17.x    | 16.x, 15.x, 14.x, 13.x  |
-| 16.x    | 14.x, 13.x              |
-| >= 15.1 | 14.x, 13.x              |
-| < 15.1  | 12.x, 11.x              |
-| 14.x    | 12.x, 11.x              |
+| Angular | Angular Testing Library      |
+| ------- | ---------------------------- |
+| 18.x    | 17.x, 16.x, 15.x, 14.x, 13.x |
+| 17.x    | 17.x, 16.x, 15.x, 14.x, 13.x |
+| 16.x    | 14.x, 13.x                   |
+| >= 15.1 | 14.x, 13.x                   |
+| < 15.1  | 12.x, 11.x                   |
+| 14.x    | 12.x, 11.x                   |


### PR DESCRIPTION
Prepare docs for ATL v17

Needs to be merged after https://github.com/testing-library/angular-testing-library/pull/460