### PR TITLE
update deferBlockBehavior documentation

### DIFF
--- a/docs/angular-testing-library/api.mdx
+++ b/docs/angular-testing-library/api.mdx
@@ -157,8 +157,7 @@ Set the defer blocks behavior.
 For more info see the
 [Angular docs](https://angular.io/api/core/testing/DeferBlockBehavior)
 
-**default** : `undefined` (uses the Angular default, which is
-`DeferBlockBehavior.Manual`)
+**default** : `undefined` (uses `DeferBlockBehavior.Manual`, which is different from the Angular default of `DeferBlockBehavior.Playthrough`)
 
 **example**:
 


### PR DESCRIPTION
Updated documentation based on [this issue regarding documentation inconsistency for deferBlockBehavior](https://github.com/testing-library/testing-library-docs/issues/1403)