### PR TITLE
chore(a11y): improving a11y score to 100% for home and doc pages

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2,8 +2,22 @@
   --ifm-light-background-color: var(--ifm-color-emphasis-100);
 }
 
+html[data-theme='light'] {
+  --ifm-color-primary: #1554B7;
+  --ifm-link-color: #1554B7;
+
+  .DocSearch-Button-Placeholder {
+    color: #494B5F;
+  }
+}
+
 html[data-theme='dark'] {
-  --ifm-link-color: #679df5;
+  --ifm-color-primary: #7FA8F1;
+  --ifm-link-color: #7FA8F1;
+
+  .DocSearch-Button-Placeholder {
+    color: white;
+  }
 }
 
 .wrapper {
@@ -73,6 +87,10 @@ html[data-theme='dark'] {
 .projectTitle {
   font-size: 250%;
   line-height: 1em;
+}
+
+.theme-doc-markdown {
+  --ifm-link-decoration: underline;
 }
 
 @media only screen and (min-width: 480px) {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2,22 +2,16 @@
   --ifm-light-background-color: var(--ifm-color-emphasis-100);
 }
 
-html[data-theme='light'] {
-  --ifm-color-primary: #1554B7;
-  --ifm-link-color: #1554B7;
-
-  .DocSearch-Button-Placeholder {
-    color: #494B5F;
-  }
-}
-
-html[data-theme='dark'] {
+[data-theme='dark']:root {
   --ifm-color-primary: #7FA8F1;
   --ifm-link-color: #7FA8F1;
+  --docsearch-muted-color: white;
+}
 
-  .DocSearch-Button-Placeholder {
-    color: white;
-  }
+[data-theme='light']:root {
+  --ifm-color-primary: #1554B7;
+  --ifm-link-color: #1554B7;
+  --docsearch-muted-color: #494B5F;
 }
 
 .wrapper {


### PR DESCRIPTION
## Details
- Improves accessibility score to 100% for home and doc pages
- used [Deque color contrast tool](https://dequeuniversity.com/rules/axe/4.9/color-contrast?application=AxeChrome) to determine closest accessible color to current color in production
- Closes issue [1405](https://github.com/testing-library/testing-library-docs/issues/1405)

## Screenshots (before/after fix)
![Screenshot 2024-08-09 at 2 06 07 PM](https://github.com/user-attachments/assets/977e2bc6-6da5-4abb-8137-208eb345e356)
![Screenshot 2024-08-09 at 2 06 26 PM](https://github.com/user-attachments/assets/17b85585-9b21-4195-8fe4-82e4053278cf)
![Screenshot 2024-08-09 at 2 06 20 PM](https://github.com/user-attachments/assets/c0df1e5e-782f-4da1-a457-ae8222cfe236)
![Screenshot 2024-08-09 at 2 06 14 PM](https://github.com/user-attachments/assets/cb515bdb-098f-44e5-b7a7-4eb9a512348e)
