### PR TITLE
fix(byrole.mdx): broken link

### DIFF
--- a/docs/queries/byrole.mdx
+++ b/docs/queries/byrole.mdx
@@ -75,7 +75,9 @@ this functionality in your test or not is up to you.
 
 :::tip input type password
 
-Unfortunately, the spec defines that `<input type="password" />` has no implicit role. This means that in order to query this type of element we must fallback to a less powerful query such as `[ByLabelText](queries/bylabeltext.mdx)`.
+Unfortunately, the spec defines that `<input type="password" />` has no implicit
+role. This means that in order to query this type of element we must fallback to
+a less powerful query such as [`ByLabelText`](queries/bylabeltext.mdx).
 
 :::
 


### PR DESCRIPTION
I fixed broken the link that was added in https://github.com/testing-library/testing-library-docs/pull/1410 .

And applied formatting using Prettier.

## before

![image](https://github.com/user-attachments/assets/60ad2c23-56b5-456a-810f-e00de4131e7f)

## after

![image](https://github.com/user-attachments/assets/f5d1d159-5cf8-43b4-aad8-4e614b0433f6)
