### PR TITLE
Update example-intro.mdx

### DIFF
--- a/docs/react-testing-library/example-intro.mdx
+++ b/docs/react-testing-library/example-intro.mdx
@@ -72,6 +72,8 @@ We recommend using the
 declaratively mock API communication in your tests instead of stubbing
 `window.fetch`, or relying on third-party adapters.
 
+Our example here uses axios to make its API calls. If your application uses [`fetch()`][https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch] to make its API calls, then be aware that by default JSDOM does not include fetch. If you are using vitest as your test runner, it will be included for you. For jest you may wish to manually polyfill `fetch()` or use the [jest-fixed-jsdom](https://github.com/mswjs/jest-fixed-jsdom) environment which includes fetch. 
+
 :::
 
 ```jsx title="__tests__/fetch.test.jsx"


### PR DESCRIPTION
Updates the example notes re: MSW to mention that jsdom doesn't include fetch and will require a polyfill