### PR TITLE
Add missing code block terminator

### DIFF
--- a/docs/react-testing-library/faq.mdx
+++ b/docs/react-testing-library/faq.mdx
@@ -113,6 +113,7 @@ test('error boundary catches error', () => {
   )
   expect(container.textContent).toEqual('Something went wrong.')
 })
+```
 
 If the error boundary did not catch the error, the test would fail since the `render` call would throw the error the Component produced.
 


### PR DESCRIPTION
You can see the issue on the current site by going to https://testing-library.com/docs/react-testing-library/faq and expanding the “How do I test error boundaries” section.