### PR TITLE
Add Vitest cleanup hint to react-testing-library setup docs

### DIFF
--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -510,3 +510,9 @@ And register it using mocha's `-r` flag:
 ```
 mocha --require ./mocha-watch-cleanup-after-each.js
 ```
+
+### Auto Cleanup in Vitest
+
+If you're using Vitest and want automatic cleanup to work, you need to
+[enable globals](https://vitest.dev/config/#globals) through its configuration
+file.

--- a/docs/react-testing-library/setup.mdx
+++ b/docs/react-testing-library/setup.mdx
@@ -513,6 +513,38 @@ mocha --require ./mocha-watch-cleanup-after-each.js
 
 ### Auto Cleanup in Vitest
 
-If you're using Vitest and want automatic cleanup to work, you need to
+If you're using Vitest and want automatic cleanup to work, you can
 [enable globals](https://vitest.dev/config/#globals) through its configuration
-file.
+file:
+
+```ts title="vitest.config.ts"
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+})
+```
+
+If you don't want to enable globals, you can import `cleanup` and call it
+manually in a top-level `afterEach` hook:
+
+```ts title="vitest.config.ts"
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['vitest-cleanup-after-each.ts'],
+  },
+})
+```
+
+```ts title="vitest-cleanup-after-each.ts"
+import {cleanup} from '@testing-library/react'
+import {afterEach} from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})
+```


### PR DESCRIPTION
This PR adds a heading to the setup guide for `react-testing-library` that explains how to get auto-cleanup working when using Vitest. The wording was inspired by a similar heading in the `vue-testing-library` setup guide: https://testing-library.com/docs/vue-testing-library/setup/#vitest