### PR TITLE
docs: add note for throwSuggestions issue #1306

### DIFF
--- a/docs/dom-testing-library/api-configuration.mdx
+++ b/docs/dom-testing-library/api-configuration.mdx
@@ -130,33 +130,33 @@ option.
 screen.getByTestId('foo', {suggest: false}) // will not throw a suggestion
 ```
 
-> :::note
->
-> When this option is enabled, the library may provide suggestions that lack an
-> intuitive implementation, this typically occurs for
-> [roles which can not be named](https://w3c.github.io/aria/#namefromprohibited),
-> most notably paragraphs. For instance, if you attempt to use
-> [`getByText`](queries/bytext.mdx), you may encounter the following error:
->
-> ```
-> TestingLibraryElementError: A better query is available, try this:
->    getByRole('paragraph')
-> ```
->
-> However, there is no direct way to query paragraphs using an object as the
-> second parameter, such as in
-> `getByRole('paragraph', { name: 'Hello World' })`.
->
-> To address this issue, you can leverage a custom function to validate the
-> element's structure and suppress the error, see
-> [#1306](https://github.com/testing-library/dom-testing-library/issues/1306)
-> and the example below:
->
-> ```js
-> getByRole('paragraph', {
->   name: (_, element) => element.textContent === 'Hello world',
-> })
-> ```
+:::note
+
+When this option is enabled, the library may provide suggestions that lack an
+intuitive implementation, this typically occurs for
+[roles which can not be named](https://w3c.github.io/aria/#namefromprohibited),
+most notably paragraphs. For instance, if you attempt to use
+[`getByText`](queries/bytext.mdx), you may encounter the following error:
+
+```
+TestingLibraryElementError: A better query is available, try this:
+    getByRole('paragraph')
+```
+
+However, there is no direct way to query paragraphs using an object as the
+second parameter, such as in
+`getByRole('paragraph', { name: 'Hello World' })`.
+
+To address this issue, you can leverage a custom function to validate the
+element's structure and suppress the error, see
+[#1306](https://github.com/testing-library/dom-testing-library/issues/1306)
+and the example below:
+
+```js
+getByRole('paragraph', {
+  name: (_, element) => element.textContent === 'Hello world',
+})
+```
 
 ### `testIdAttribute`
 

--- a/docs/dom-testing-library/api-configuration.mdx
+++ b/docs/dom-testing-library/api-configuration.mdx
@@ -147,9 +147,8 @@ However, there is no direct way to query paragraphs using the config object para
 `getByRole('paragraph', { name: 'Hello World' })`.
 
 To address this issue, you can leverage a custom function to validate the
-element's structure and suppress the error, see
-[#1306](https://github.com/testing-library/dom-testing-library/issues/1306)
-and the example below:
+element's structure, as shown in the example below.
+More information can be found in the [GitHub issue](https://github.com/testing-library/dom-testing-library/issues/1306)
 
 ```js
 getByRole('paragraph', {

--- a/docs/dom-testing-library/api-configuration.mdx
+++ b/docs/dom-testing-library/api-configuration.mdx
@@ -130,6 +130,34 @@ option.
 screen.getByTestId('foo', {suggest: false}) // will not throw a suggestion
 ```
 
+> **Note**
+>
+> When this option is enabled, the library may provide suggestions that lack an
+> intuitive implementation. This typically occurs for
+> [roles which can not be named](https://w3c.github.io/aria/#namefromprohibited),
+> most notably paragraphs. For instance, if you attempt to use
+> [`getByText`](queries/bytext.mdx), you may encounter the following error:
+>
+> ```
+> TestingLibraryElementError: A better query is available, try this:
+>    getByRole('paragraph')
+> ```
+>
+> However, there is no direct way to query paragraphs using an object as the
+> second parameter, such as in
+> `getByRole('paragraph', { name: 'Hello World' })`.
+>
+> To address this issue, you can leverage a custom function to validate the
+> element's structure and suppress the error, see
+> [#1306](https://github.com/testing-library/dom-testing-library/issues/1306)
+> and the example below:
+>
+> ```js
+> getByRole('paragraph', {
+>   name: (_, element) => element.textContent === 'Hello world!',
+> })
+> ```
+
 ### `testIdAttribute`
 
 The attribute used by [`getByTestId`](queries/bytestid.mdx) and related queries.

--- a/docs/dom-testing-library/api-configuration.mdx
+++ b/docs/dom-testing-library/api-configuration.mdx
@@ -143,8 +143,7 @@ TestingLibraryElementError: A better query is available, try this:
     getByRole('paragraph')
 ```
 
-However, there is no direct way to query paragraphs using an object as the
-second parameter, such as in
+However, there is no direct way to query paragraphs using the config object parameter, such as in
 `getByRole('paragraph', { name: 'Hello World' })`.
 
 To address this issue, you can leverage a custom function to validate the

--- a/docs/dom-testing-library/api-configuration.mdx
+++ b/docs/dom-testing-library/api-configuration.mdx
@@ -158,6 +158,8 @@ getByRole('paragraph', {
 })
 ```
 
+:::
+
 ### `testIdAttribute`
 
 The attribute used by [`getByTestId`](queries/bytestid.mdx) and related queries.

--- a/docs/dom-testing-library/api-configuration.mdx
+++ b/docs/dom-testing-library/api-configuration.mdx
@@ -130,7 +130,7 @@ option.
 screen.getByTestId('foo', {suggest: false}) // will not throw a suggestion
 ```
 
-> **Note**
+> :::note
 >
 > When this option is enabled, the library may provide suggestions that lack an
 > intuitive implementation, this typically occurs for

--- a/docs/dom-testing-library/api-configuration.mdx
+++ b/docs/dom-testing-library/api-configuration.mdx
@@ -133,7 +133,7 @@ screen.getByTestId('foo', {suggest: false}) // will not throw a suggestion
 > **Note**
 >
 > When this option is enabled, the library may provide suggestions that lack an
-> intuitive implementation. This typically occurs for
+> intuitive implementation, this typically occurs for
 > [roles which can not be named](https://w3c.github.io/aria/#namefromprohibited),
 > most notably paragraphs. For instance, if you attempt to use
 > [`getByText`](queries/bytext.mdx), you may encounter the following error:
@@ -154,7 +154,7 @@ screen.getByTestId('foo', {suggest: false}) // will not throw a suggestion
 >
 > ```js
 > getByRole('paragraph', {
->   name: (_, element) => element.textContent === 'Hello world!',
+>   name: (_, element) => element.textContent === 'Hello world',
 > })
 > ```
 

--- a/docs/dom-testing-library/api-configuration.mdx
+++ b/docs/dom-testing-library/api-configuration.mdx
@@ -132,9 +132,9 @@ screen.getByTestId('foo', {suggest: false}) // will not throw a suggestion
 
 :::note
 
-When this option is enabled, the library may provide suggestions that lack an
-intuitive implementation, this typically occurs for
-[roles which can not be named](https://w3c.github.io/aria/#namefromprohibited),
+When this option is enabled, it may provide suggestions that lack an
+intuitive implementation. Typically this happens for
+[roles which cannot be named](https://w3c.github.io/aria/#namefromprohibited),
 most notably paragraphs. For instance, if you attempt to use
 [`getByText`](queries/bytext.mdx), you may encounter the following error:
 


### PR DESCRIPTION
As discussed with @MatanBobi  and @timdeschryver this is the documentation change to account for issue found with the `throwSuggestions` option when enforced.

For more context, this is discussed and related to issue [#1306 in dom-testing-library](https://github.com/testing-library/dom-testing-library/issues/1306).

### Testing instructions 
- Go to [/docs/dom-testing-library/api-configuration/#throwsuggestions-experimental](https://deploy-preview-1425--testing-library.netlify.app/docs/dom-testing-library/api-configuration/#throwsuggestions-experimental)
- Read the newly added note in the throwSuggestions section.