### PR TITLE
Remove contradiction from documentation

### DIFF
--- a/docs/react-testing-library/intro.mdx
+++ b/docs/react-testing-library/intro.mdx
@@ -9,11 +9,10 @@ APIs for working with React components.
 
 ## Installation
 
-To get started with `React Testing Library`, you'll need to install it together
-with its peerDependency `@testing-library/dom`:
+To get started with `React Testing Library`, you'll need to install it.
 
 ```bash npm2yarn
-npm install --save-dev @testing-library/react @testing-library/dom
+npm install --save-dev @testing-library/react
 ```
 
 ### With TypeScript
@@ -22,7 +21,7 @@ To get full type coverage, you need to install the types for `react` and `react-
 well:
 
 ```bash npm2yarn
-npm install --save-dev @testing-library/react @testing-library/dom @types/react @types/react-dom
+npm install --save-dev @testing-library/react @types/react @types/react-dom
 ```
 
 [gh]: https://github.com/testing-library/react-testing-library


### PR DESCRIPTION
I found something confusing in the documentation regarding testing-library-dom

[Here](https://testing-library.com/docs/user-event/install/) you say that testing-library-dom should be resolved via the framework wrapper 

And when you then go to the [actual framework wrapper](https://testing-library.com/docs/react-testing-library/intro) (in my case react) it states the following:

> To get started with React Testing Library, you'll need to install it together with its peerDependency @testing-library/dom:
`npm install --save-dev @testing-library/react @testing-library/dom`

but this contradicts what is said earlier right?