### PR TITLE
docs(qwik): adjust setup instructions

### DIFF
--- a/docs/qwik-testing-library/setup.mdx
+++ b/docs/qwik-testing-library/setup.mdx
@@ -4,18 +4,6 @@ title: Setup
 sidebar_label: Setup
 ---
 
-The easiest way to get started with Qwik Testing Library is to use the Qwik CLI
-that comes with your Qwik project to automatically set it up for you:
-
-```bash npm2yarn
-npm run qwik add testing-library
-```
-
-If you prefer to set it up manually or want to understand what the setup script
-does, read along...
-
-## Manual Setup
-
 This module is distributed via [npm][npm] which is bundled with [node][node] and
 should be installed as one of your project's `devDependencies`:
 


### PR DESCRIPTION
@shairez made me realize the setup instructions were still mentioning `pnpm qwik add testing-library` as a quick way to setup the library even though it's not ready yet.

Let's just remove it and keep only the manual instructions for now. I'll make another PR to put it back once it's ready. Sorry about that! :pray: 