### PR TITLE
docs(qwik): remove qwik cli command from the intro

### DIFF
--- a/docs/qwik-testing-library/intro.mdx
+++ b/docs/qwik-testing-library/intro.mdx
@@ -8,15 +8,6 @@ sidebar_label: Introduction
 
 [gh]: https://github.com/ianlet/qwik-testing-library
 
-```bash npm2yarn
-npm run qwik add testing-library
-```
-
-> This library is built on top of [`dom-testing-library`][dom-testing-library]
-> which is where most of the logic behind the queries is.
-
-[dom-testing-library]: ../dom-testing-library/intro.mdx
-
 ## The Problem
 
 You want to write maintainable tests for your [Qwik][qwik] components.


### PR DESCRIPTION
I forgot the qwik cli was also mentioned in the intro page. Let's remove it there as well as it's not ready yet.