### PR TITLE
fix(a11y): underline links in a text block as pur WCAG 2.0

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -3,15 +3,15 @@
 }
 
 [data-theme='dark']:root {
-  --ifm-color-primary: #7FA8F1;
-  --ifm-link-color: #7FA8F1;
+  --ifm-color-primary: #7fa8f1;
+  --ifm-link-color: #7fa8f1;
   --docsearch-muted-color: white;
 }
 
 [data-theme='light']:root {
-  --ifm-color-primary: #1554B7;
-  --ifm-link-color: #1554B7;
-  --docsearch-muted-color: #494B5F;
+  --ifm-color-primary: #1554b7;
+  --ifm-link-color: #1554b7;
+  --docsearch-muted-color: #494b5f;
 }
 
 .wrapper {
@@ -481,6 +481,10 @@ details.alert {
 details.alert div {
   border-top: none;
   padding-top: 0;
+}
+
+.linkInTextBlock a {
+  text-decoration: underline;
 }
 
 @media only screen and (min-width: 1024px) {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -483,7 +483,7 @@ details.alert div {
   padding-top: 0;
 }
 
-.linkInTextBlock a {
+.textBlockWithLinks a {
   text-decoration: underline;
 }
 

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -64,18 +64,20 @@ export default function Help(props) {
               <h1 className="help-heading-1">Need help?</h1>
             </header>
             <GridBlock
+              className="linkInTextBlock"
               contents={supportLinks.slice(0, 3)}
               layout="threeColumn"
               align="left"
             />
             <GridBlock
+              className="linkInTextBlock"
               contents={supportLinks.slice(3)}
               layout="threeColumn"
               align="left"
             />
             <section>
               <h2 className="help-heading-2">Buy a course</h2>
-              <p>
+              <p className="linkInTextBlock">
                 Learn how to test JavaScript with{' '}
                 <ExternalLink href="https://kentcdodds.com">
                   Kent C. Dodds
@@ -105,7 +107,7 @@ export default function Help(props) {
               community successful and improve tests for everyone in the long
               run.
             </p>
-            <p>
+            <p className="linkInTextBlock">
               Please consider helping us answer community questions and update
               documentation content via the help links above. You can also help
               support{' '}

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -64,20 +64,20 @@ export default function Help(props) {
               <h1 className="help-heading-1">Need help?</h1>
             </header>
             <GridBlock
-              className="linkInTextBlock"
+              className="textBlockWithLinks"
               contents={supportLinks.slice(0, 3)}
               layout="threeColumn"
               align="left"
             />
             <GridBlock
-              className="linkInTextBlock"
+              className="textBlockWithLinks"
               contents={supportLinks.slice(3)}
               layout="threeColumn"
               align="left"
             />
             <section>
               <h2 className="help-heading-2">Buy a course</h2>
-              <p className="linkInTextBlock">
+              <p className="textBlockWithLinks">
                 Learn how to test JavaScript with{' '}
                 <ExternalLink href="https://kentcdodds.com">
                   Kent C. Dodds
@@ -107,7 +107,7 @@ export default function Help(props) {
               community successful and improve tests for everyone in the long
               run.
             </p>
-            <p className="linkInTextBlock">
+            <p className="textBlockWithLinks">
               Please consider helping us answer community questions and update
               documentation content via the help links above. You can also help
               support{' '}


### PR DESCRIPTION
As per WCAG 2.0 guidelines, links must be visually distinguishable from normal text when they are in a text block without relying on color. This PR remediates that issue for the "Help" page.

Current Help Page in production: https://testing-library.com/help 

https://dequeuniversity.com/rules/axe/4.10/link-in-text-block?application=AxeChrome
https://www.w3.org/TR/WCAG20-TECHS/F73.html

<img width="780" alt="image" src="https://github.com/user-attachments/assets/ada4b5c3-c68c-4d4f-852b-912cb7823bf3">
