### PR TITLE
docs: Update Vue Testing Library Sidebar Order

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -115,8 +115,8 @@ module.exports = {
             'vue-testing-library/examples',
             'vue-testing-library/setup',
             'vue-testing-library/api',
-            'vue-testing-library/cheatsheet',
             'vue-testing-library/faq',
+            'vue-testing-library/cheatsheet',
           ],
         },
         {


### PR DESCRIPTION
Match React Testing Library for better organization.

I noticed this today while I was reading through the Vue Testing Library docs for the first time, and noticed that the order of the docs in the sidebar was not the same as the React Testing Library docs that I look at all the time. I believe the order of the sidebar links should match across projects, and the rest of the projects and links do match as far as I can tell!