### PR TITLE
use consistant naming in sidebar and titles

### DIFF
--- a/docs/angular-testing-library/examples.mdx
+++ b/docs/angular-testing-library/examples.mdx
@@ -1,6 +1,6 @@
 ---
 id: examples
-title: Examples
+title: Example
 ---
 
 > Read about

--- a/docs/bs-react-testing-library/examples.mdx
+++ b/docs/bs-react-testing-library/examples.mdx
@@ -1,6 +1,6 @@
 ---
 id: examples
-title: Examples
+title: Example
 ---
 
 You can find more bs-dom-testing-library examples at

--- a/docs/vue-testing-library/examples.mdx
+++ b/docs/vue-testing-library/examples.mdx
@@ -1,6 +1,6 @@
 ---
 id: examples
-title: Examples
+title: Example
 ---
 
 ## Basic example

--- a/sidebars.js
+++ b/sidebars.js
@@ -131,8 +131,8 @@ module.exports = {
         {
           'Svelte Testing Library': [
             'svelte-testing-library/intro',
-            'svelte-testing-library/setup',
             'svelte-testing-library/example',
+            'svelte-testing-library/setup',
             'svelte-testing-library/api',
             'svelte-testing-library/faq',
           ],
@@ -174,8 +174,8 @@ module.exports = {
         {
           'Qwik Testing Library': [
             'qwik-testing-library/intro',
-            'qwik-testing-library/setup',
             'qwik-testing-library/example',
+            'qwik-testing-library/setup',
             'qwik-testing-library/api',
             'qwik-testing-library/faq',
           ],


### PR DESCRIPTION
Follow-up of #1459 to add more consistency in the sidebar and titles.

This PR:
- rearranges the sidebar to follow React's order
- rename "Examples" to "Example" 