### PR TITLE
Add missing documentation about using `@testing-library/jest-dom` with TypeScript

### DIFF
--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -138,6 +138,18 @@ runner that's ESM compatible.
 [resolve-conditions]:
   https://vitejs.dev/config/shared-options.html#resolve-conditions
 
+### TypeScript
+
+If you use TypeScript and want to use [`@testing-library/jest-dom`][@testing-library/jest-dom] you need to tell the TypeScript compiler about [`@testing-library/jest-dom`][@testing-library/jest-dom] by adding it in your `tsconfig.json` to the `compilerOptions`.
+
+```json title="package.json"
+{
+  "compilerOptions": {
+	"types": ["@testing-library/jest-dom"],
+  }
+}
+```
+
 ## Jest
 
 [`@testing-library/svelte`][@testing-library/svelte] is ESM-only, which means

--- a/docs/svelte-testing-library/setup.mdx
+++ b/docs/svelte-testing-library/setup.mdx
@@ -140,9 +140,9 @@ runner that's ESM compatible.
 
 ### TypeScript
 
-If you use TypeScript and want to use [`@testing-library/jest-dom`][@testing-library/jest-dom] you need to tell the TypeScript compiler about [`@testing-library/jest-dom`][@testing-library/jest-dom] by adding it in your `tsconfig.json` to the `compilerOptions`.
+Include [`@testing-library/jest-dom`][@testing-library/jest-dom] to the TypeScript `types` to make the TypeScript compiler aware about the [`@testing-library/jest-dom`][@testing-library/jest-dom] matchers.
 
-```json title="package.json"
+```json title="tsconfig.json"
 {
   "compilerOptions": {
 	"types": ["@testing-library/jest-dom"],


### PR DESCRIPTION
As I found out with my SvelteKit 5 project, we need to add `"types": ["@testing-library/jest-dom"]` to the `compilerOptions` in the project's `tsconfig.json`. Otherwise VSCode complains that it can't find e.g. `toBeInTheDocument` (Property 'toBeInTheDocument' does not exist on type 'Assertion<HTMLElement>'.ts(2339)).

I'm no TypeScript Pro, so feel free to reword what I wrote.  :-)