### PR TITLE
docs(Vue Testing Library): update `@vue/test-utils` link urls in api page to vue3

### DIFF
--- a/docs/vue-testing-library/api.mdx
+++ b/docs/vue-testing-library/api.mdx
@@ -58,7 +58,7 @@ The valid Vue Component to be tested.
 #### Options
 
 An object containing additional information to be passed to `@vue/test-utils`
-[mount](https://vue-test-utils.vuejs.org/api/options.html#mounting-options).
+[mount](https://test-utils.vuejs.org/api/#mount).
 
 Additionally, the following options can also be provided:
 
@@ -171,22 +171,21 @@ This is a simple wrapper around `prettyDOM` which is also exposed and comes from
 #### `unmount()`
 
 An alias for `@vue/test-utils`
-[destroy](https://vue-test-utils.vuejs.org/api/wrapper/#destroy).
+[unmount](https://test-utils.vuejs.org/api/#unmount).
 
 #### `html()`
 
-An alias for `@vue/test-utils`
-[html](https://vue-test-utils.vuejs.org/api/wrapper/#html).
+An alias for `@vue/test-utils` [html](https://test-utils.vuejs.org/api/#html).
 
 #### `emitted()`
 
 An alias for `@vue/test-utils`
-[emitted](https://vue-test-utils.vuejs.org/api/wrapper/#emitted).
+[emitted](https://test-utils.vuejs.org/api/#emitted).
 
 #### `rerender(props)`
 
 An alias for `@vue/test-utils`
-[setProps](https://test-utils.vuejs.org/api/#setprops).
+[setProps](https://test-utils.vuejs.org/api/#setProps).
 
 It returns a Promise through so you can `await rerender(...)`.
 

--- a/docs/vue-testing-library/faq.mdx
+++ b/docs/vue-testing-library/faq.mdx
@@ -156,8 +156,8 @@ Links:
 <!-- prettier-ignore-start -->
 
 [vue-test-utils]: https://github.com/vuejs/vue-test-utils
-[mount]: https://vue-test-utils.vuejs.org/api/#mount
-[stubs]: https://vue-test-utils.vuejs.org/api/options.html#stubs
+[mount]: https://test-utils.vuejs.org/api/#mount
+[stubs]: https://test-utils.vuejs.org/api/#global-stubs
 [stubs-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/stubs.js
 
 <!-- prettier-ignore-end -->

--- a/docs/vue-testing-library/faq.mdx
+++ b/docs/vue-testing-library/faq.mdx
@@ -158,6 +158,6 @@ Links:
 [vue-test-utils]: https://github.com/vuejs/vue-test-utils
 [mount]: https://test-utils.vuejs.org/api/#mount
 [stubs]: https://test-utils.vuejs.org/api/#global-stubs
-[stubs-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/stubs.js
+[stubs-example]: https://github.com/testing-library/vue-testing-library/blob/main/src/__tests__/stubs.js
 
 <!-- prettier-ignore-end -->

--- a/docs/vue-testing-library/faq.mdx
+++ b/docs/vue-testing-library/faq.mdx
@@ -43,7 +43,7 @@ In general, you should avoid mocking out components (see
 
 However if you need to, you can either use Jest's
 [mocking feature](https://facebook.github.io/jest/docs/en/manual-mocks.html) or
-the [`stubs`][stubs] key provided by @vue/test-utils.
+the [`global.stubs`][stubs] key provided by @vue/test-utils.
 
 ```js
 import {render} from '@testing-library/vue'


### PR DESCRIPTION
# Change Summary

This pull request updates several links on the Vue Testing Library API page.

Previously, these links for `@vue/test-utils` were directing users to the documentation site for Vue v2.x and earlier.  
Since today's Vue version is 3.x, I update these links to the `@vue/test-utils` documentation site for Vue 3.
