### PR TITLE
untangle syntax in intro.mdx

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -46,8 +46,7 @@ Testing Library encourages you to avoid testing
 [implementation details](https://kentcdodds.com/blog/testing-implementation-details)
 like the internals of a component you're testing (though it's still possible).
 [The Guiding Principles](/docs/guiding-principles) of this library emphasize a
-focus on tests that closely resemble how your web pages are interacted by the
-users.
+focus on tests that closely resemble how users interact with your web pages.
 
 You may want to avoid the following implementation details:
 


### PR DESCRIPTION
The simplest correction would be this:

> [The Guiding Principles](/docs/guiding-principles) of this library emphasize a focus on tests that closely resemble how your web pages are interacted with by the users.

but I'm guessing that the "with" was avoided since some people prefer not to use that sort of syntax (even though it's actually perfectly normal and conventional).  So I'm proposing another alternative here that avoids putting two prepositions next to each other.