### PR TITLE
docs: use queryByText in guide-disappearance.mdx

### DIFF
--- a/docs/guide-disappearance.mdx
+++ b/docs/guide-disappearance.mdx
@@ -31,8 +31,10 @@ test('movie title appears', async () => {
   // element is initially not present...
 
   // wait for appearance inside an assertion
+  // note use of queryBy instead of getBy to return null
+  // instead of throwing in the query itself
   await waitFor(() => {
-    expect(getByText('the lion king')).toBeInTheDocument()
+    expect(queryByText('the lion king')).toBeInTheDocument()
   })
 })
 ```


### PR DESCRIPTION
This adjusts the first example on this page to use the `queryBy` finder instead of `getBy` to avoid throwing in the query itself.

This gotcha gets explained a few times later in the doc (https://testing-library.com/docs/guide-disappearance#waiting-for-disappearance) but this is the first example you come to, and the use of `getByText` means the `expect(...).toBeInTheDocument()` will never be called.