### PR TITLE
Fix grammar mistakes in docs

### DIFF
--- a/blog/2019-04-25-new-org.mdx
+++ b/blog/2019-04-25-new-org.mdx
@@ -47,7 +47,7 @@ and
 [cypress-testing-library](https://github.com/testing-library/cypress-testing-library)
 have already been updated and released major version bumps of their own to
 account for this upgrade. Other wrappers will hopefully follow shortly based on
-their respective matinainers' schedules.
+their respective maintainers' schedules.
 
 > [View the Changelog](https://github.com/testing-library/dom-testing-library/releases/tag/v4.0.0)
 

--- a/docs/angular-testing-library/api.mdx
+++ b/docs/angular-testing-library/api.mdx
@@ -300,7 +300,7 @@ await render(AppComponent, {detectChangesOnRender: false})
 ### `autoDetectChanges`
 
 Automatically detect changes as a "real" running component would do. For
-example, runs a change detection cycle when an event has occured.
+example, runs a change detection cycle when an event has occurred.
 
 **default** : `true`
 

--- a/docs/example-react-intl.mdx
+++ b/docs/example-react-intl.mdx
@@ -130,11 +130,11 @@ test('it should render FormattedDate and have a formatted pt date', () => {
 })
 ```
 
-## Translated components testing stategy
+## Translated components testing strategy
 
 When testing a translated component there can be different approaches for
 achieving the wanted coverage, where the aimed goal should be to allow testing
-the component in a way that will simulate the user behavior as much as posible.
+the component in a way that will simulate the user behavior as much as possible.
 
 | Approach                                   | Pros                                                                                                                                                                                                                                                                                 | Cons                                                                                                                                                                                                                                                                  |
 | ------------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/marko-testing-library/intro.mdx
+++ b/docs/marko-testing-library/intro.mdx
@@ -33,7 +33,7 @@ better testing practices. Its primary guiding principle is:
 
 So rather than dealing with instances of rendered Marko components, your tests
 will work with actual DOM nodes. The utilities this library provides facilitate
-querying the DOM in the same way the user would. Finding for elements by their
+querying the DOM in the same way the user would. Finding elements by their
 label text (just like a user would), finding links and buttons from their text
 (like a user would). It contains a small targeted API and can get out of your
 way if needed with some built-in escape hatches.

--- a/docs/nightwatch-testing-library/intro.mdx
+++ b/docs/nightwatch-testing-library/intro.mdx
@@ -21,7 +21,7 @@ npm install --save-dev @testing-library/nightwatch
 
 ## READ THIS FIRST
 
-At it's core, `nightwatch-testing-library` translates between
+At its core, `nightwatch-testing-library` translates between
 dom-testing-library queries and css selectors. This is due to the fact that
 Nightwatch adheres to the WebDriver standards for
 [locator strategies](https://www.w3.org/TR/webdriver/#locator-strategies). For

--- a/docs/webdriverio-testing-library/intro.mdx
+++ b/docs/webdriverio-testing-library/intro.mdx
@@ -24,7 +24,7 @@ npm install --save-dev @testing-library/webdriverio
 ### `setupBrowser`
 
 Accepts a WebdriverIO [browser object](https://webdriver.io/docs/browserobject)
-and returns dom-testing-library [queries](/docs/queries/about.mdx) modifed to return
+and returns dom-testing-library [queries](/docs/queries/about.mdx) modified to return
 WebdriverIO elements like normal
 [selectors](https://webdriver.io/docs/selectors/). **All queries are async** and
 are bound to `document.body` by default.


### PR DESCRIPTION
## Why
A few documentation pages had clear spelling and grammar mistakes that make the docs look rougher than intended.

## What changed
This updates six documentation files to fix seven straightforward wording issues, including misspellings like `maintainers`, `occurred`, `strategy`, `possible`, and `modified`, plus a couple of small grammar fixes.

## Notes
This is a text-only cleanup with no behavior changes.