### PR TITLE
Add @accesslint/jest and @accesslint/vitest to the Ecosystem

### DIFF
--- a/docs/ecosystem-accesslint-jest.mdx
+++ b/docs/ecosystem-accesslint-jest.mdx
@@ -1,0 +1,38 @@
+---
+id: ecosystem-accesslint-jest
+title: accesslint/jest
+---
+
+[`@accesslint/jest`][gh] is a companion library for Testing Library that adds a
+synchronous `toBeAccessible()` matcher for Jest, covering WCAG 2.2 Level A and
+AA accessibility rules. Works under `jsdom` and `happy-dom`.
+
+```bash npm2yarn
+npm install --save-dev @accesslint/jest
+```
+
+Register the matcher once via `setupFilesAfterEnv` in your Jest config, then
+assert on any rendered element:
+
+```jsx
+import { render } from '@testing-library/react'
+import { LoginForm } from './LoginForm'
+
+test('LoginForm is accessible', () => {
+  const { container } = render(<LoginForm />)
+  expect(container).toBeAccessible()
+})
+```
+
+Violations are scoped to the element you pass, so components can be tested in
+isolation. Options include `disabledRules`, `failOn` impact thresholds, and
+snapshot baselines that auto-ratchet as you fix violations.
+
+Check out [@accesslint/jest's documentation][gh] for setup, options, and a
+migration guide from `jest-axe`.
+
+- [@accesslint/jest on GitHub][gh]
+- [@accesslint/jest on npm][npm]
+
+[gh]: https://github.com/AccessLint/accesslint/tree/main/jest
+[npm]: https://www.npmjs.com/package/@accesslint/jest

--- a/docs/ecosystem-accesslint-vitest.mdx
+++ b/docs/ecosystem-accesslint-vitest.mdx
@@ -1,0 +1,35 @@
+---
+id: ecosystem-accesslint-vitest
+title: accesslint/vitest
+---
+
+[`@accesslint/vitest`][gh] is a companion library for Testing Library that adds
+a synchronous `toBeAccessible()` matcher for Vitest, covering WCAG 2.2 Level A
+and AA accessibility rules. Works under `jsdom` and `happy-dom`.
+
+```bash npm2yarn
+npm install --save-dev @accesslint/vitest
+```
+
+Add it as a setup file in your Vitest config, then assert on any rendered
+element:
+
+```jsx
+import { render } from '@testing-library/react'
+import { LoginForm } from './LoginForm'
+
+test('LoginForm is accessible', () => {
+  const { container } = render(<LoginForm />)
+  expect(container).toBeAccessible()
+})
+```
+
+Options include `disabledRules`, `failOn` impact thresholds, an opt-in audit
+memoization fixture for component tests that chain multiple assertions, and
+snapshot baselines that auto-ratchet as you fix violations.
+
+- [@accesslint/vitest on GitHub][gh]
+- [@accesslint/vitest on npm][npm]
+
+[gh]: https://github.com/AccessLint/accesslint/tree/main/vitest
+[npm]: https://www.npmjs.com/package/@accesslint/vitest

--- a/sidebars.js
+++ b/sidebars.js
@@ -218,6 +218,8 @@ module.exports = {
         'ecosystem-rtl-simple-queries',
         'ecosystem-testing-library-selector',
         'ecosystem-cli-testing-library',
+        'ecosystem-accesslint-jest',
+        'ecosystem-accesslint-vitest',
       ],
     },
   ],


### PR DESCRIPTION
Adds two new Ecosystem entries for the `@accesslint/*` accessibility-matcher packages. Both provide a `toBeAccessible()` matcher that works with any DOM produced by Testing Library (`container`, `screen.getByRole(...)`, etc.) — the same matcher composes across `@testing-library/react`, `@testing-library/vue`, `@testing-library/svelte`, and `@testing-library/angular`.

The libraries are synchronous, run under `jsdom` and `happy-dom`, and cover WCAG 2.2 Level A and AA via [`@accesslint/core`](https://github.com/AccessLint/accesslint/tree/main/core).

Follows the same page structure as `ecosystem-jasmine-dom` and `ecosystem-jest-native`.